### PR TITLE
session: Return error instead of logging with AWS Account ID lookup failure

### DIFF
--- a/session.go
+++ b/session.go
@@ -185,13 +185,10 @@ func GetSessionWithAccountIDAndPartition(c *Config) (*session.Session, string, s
 			return sess, accountID, partition, nil
 		}
 
-		// DEPRECATED: Next major version of the provider should return the error instead of logging
-		//             if skip_request_account_id is not enabled.
-		log.Printf("[WARN] %s", fmt.Sprintf(
+		return nil, "", "", fmt.Errorf(
 			"AWS account ID not previously found and failed retrieving via all available methods. "+
-				"This will return an error in the next major version of the AWS provider. "+
 				"See https://www.terraform.io/docs/providers/aws/index.html#skip_requesting_account_id for workaround and implications. "+
-				"Errors: %s", err))
+				"Errors: %s", err)
 	}
 
 	var partition string


### PR DESCRIPTION
This update was missed during the library migration and matches this previously approved pull request: https://github.com/terraform-providers/terraform-provider-aws/pull/5795

I have created an issue to add testing for this code: https://github.com/hashicorp/aws-sdk-go-base/issues/2