### PR TITLE
Ensure proper order for obtaining credentials, assuming roles, using profiles

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -22,6 +22,14 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+const (
+	// errMsgNoValidCredentialSources error getting credentials
+	errMsgNoValidCredentialSources = `No valid credential sources found for AWS Provider.
+	Please see https://terraform.io/docs/providers/aws/index.html for more information on
+	providing credentials for the AWS Provider`
+)
+
+// GetAccountIDAndPartition gets the account ID and associated partition.
 func GetAccountIDAndPartition(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string) (string, string, error) {
 	var accountID, partition string
 	var err, errors error
@@ -51,6 +59,8 @@ func GetAccountIDAndPartition(iamconn *iam.IAM, stsconn *sts.STS, authProviderNa
 	return accountID, partition, errors
 }
 
+// GetAccountIDAndPartitionFromEC2Metadata gets the account ID and associated
+// partition from EC2 metadata.
 func GetAccountIDAndPartitionFromEC2Metadata() (string, string, error) {
 	log.Println("[DEBUG] Trying to get account information via EC2 Metadata")
 
@@ -75,6 +85,8 @@ func GetAccountIDAndPartitionFromEC2Metadata() (string, string, error) {
 	return parseAccountIDAndPartitionFromARN(info.InstanceProfileArn)
 }
 
+// GetAccountIDAndPartitionFromIAMGetUser gets the account ID and associated
+// partition from IAM.
 func GetAccountIDAndPartitionFromIAMGetUser(iamconn *iam.IAM) (string, string, error) {
 	log.Println("[DEBUG] Trying to get account information via iam:GetUser")
 
@@ -102,6 +114,8 @@ func GetAccountIDAndPartitionFromIAMGetUser(iamconn *iam.IAM) (string, string, e
 	return parseAccountIDAndPartitionFromARN(aws.StringValue(output.User.Arn))
 }
 
+// GetAccountIDAndPartitionFromIAMListRoles gets the account ID and associated
+// partition from listing IAM roles.
 func GetAccountIDAndPartitionFromIAMListRoles(iamconn *iam.IAM) (string, string, error) {
 	log.Println("[DEBUG] Trying to get account information via iam:ListRoles")
 
@@ -123,6 +137,8 @@ func GetAccountIDAndPartitionFromIAMListRoles(iamconn *iam.IAM) (string, string,
 	return parseAccountIDAndPartitionFromARN(aws.StringValue(output.Roles[0].Arn))
 }
 
+// GetAccountIDAndPartitionFromSTSGetCallerIdentity gets the account ID and associated
+// partition from STS caller identity.
 func GetAccountIDAndPartitionFromSTSGetCallerIdentity(stsconn *sts.STS) (string, string, error) {
 	log.Println("[DEBUG] Trying to get account information via sts:GetCallerIdentity")
 
@@ -148,9 +164,54 @@ func parseAccountIDAndPartitionFromARN(inputARN string) (string, string, error) 
 	return arn.AccountID, arn.Partition, nil
 }
 
-// This function is responsible for reading credentials from the
-// environment in the case that they're not explicitly specified
-// in the Terraform configuration.
+// GetCredentialsFromSession returns credentials derived from a session. A
+// session uses the AWS SDK Go chain of providers so may use a provider (e.g.,
+// ProcessProvider) that is not part of the Terraform provider chain.
+func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
+	log.Printf("[INFO] Attempting to use session-derived credentials")
+
+	var sess *session.Session
+	var err error
+	if c.Profile == "" {
+		sess, err = session.NewSession()
+		if err != nil {
+			return nil, errors.New(errMsgNoValidCredentialSources)
+		}
+	} else {
+		options := &session.Options{
+			Config: aws.Config{
+				HTTPClient: cleanhttp.DefaultClient(),
+				MaxRetries: aws.Int(0),
+				Region:     aws.String(c.Region),
+			},
+		}
+		options.Profile = c.Profile
+		options.SharedConfigState = session.SharedConfigEnable
+
+		sess, err = session.NewSessionWithOptions(*options)
+		if err != nil {
+			if IsAWSErr(err, "NoCredentialProviders", "") {
+				return nil, errors.New(errMsgNoValidCredentialSources)
+			}
+			return nil, fmt.Errorf("Error creating AWS session: %s", err)
+		}
+	}
+
+	creds := sess.Config.Credentials
+	cp, err := sess.Config.Credentials.Get()
+	if err != nil {
+		return nil, errors.New(errMsgNoValidCredentialSources)
+	}
+
+	log.Printf("[INFO] Successfully derived credentials from session")
+	log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
+	return creds, nil
+}
+
+// GetCredentials gets credentials from the environment, shared credentials,
+// or the session (which may include a credential process). GetCredentials also
+// validates the credentials and the ability to assume a role or will return an
+// error if unsuccessful.
 func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	// build a chain provider, lazy-evaluated by aws-sdk
 	providers := []awsCredentials.Provider{
@@ -225,29 +286,31 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 		}
 	}
 
+	// Validate the credentials before returning them
+	creds := awsCredentials.NewChainCredentials(providers)
+	cp, err := creds.Get()
+	if err != nil {
+		if IsAWSErr(err, "NoCredentialProviders", "") {
+			creds, err = GetCredentialsFromSession(c)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
+		}
+	} else {
+		log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
+	}
+
 	// This is the "normal" flow (i.e. not assuming a role)
 	if c.AssumeRoleARN == "" {
-		return awsCredentials.NewChainCredentials(providers), nil
+		return creds, nil
 	}
 
 	// Otherwise we need to construct an STS client with the main credentials, and verify
 	// that we can assume the defined role.
 	log.Printf("[INFO] Attempting to AssumeRole %s (SessionName: %q, ExternalId: %q, Policy: %q)",
 		c.AssumeRoleARN, c.AssumeRoleSessionName, c.AssumeRoleExternalID, c.AssumeRolePolicy)
-
-	creds := awsCredentials.NewChainCredentials(providers)
-	cp, err := creds.Get()
-	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-			return nil, errors.New(`No valid credential sources found for AWS Provider.
-  Please see https://terraform.io/docs/providers/aws/index.html for more information on
-  providing credentials for the AWS Provider`)
-		}
-
-		return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
-	}
-
-	log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
 
 	awsConfig := &aws.Config{
 		Credentials: creds,

--- a/awsauth.go
+++ b/awsauth.go
@@ -29,6 +29,13 @@ const (
 	providing credentials for the AWS Provider`
 )
 
+var (
+	// ErrNoValidCredentialSources indicates that no credentials source could be found
+	ErrNoValidCredentialSources = errNoValidCredentialSources()
+)
+
+func errNoValidCredentialSources() error { return errors.New(errMsgNoValidCredentialSources) }
+
 // GetAccountIDAndPartition gets the account ID and associated partition.
 func GetAccountIDAndPartition(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string) (string, string, error) {
 	var accountID, partition string
@@ -175,7 +182,7 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 	if c.Profile == "" {
 		sess, err = session.NewSession()
 		if err != nil {
-			return nil, errors.New(errMsgNoValidCredentialSources)
+			return nil, ErrNoValidCredentialSources
 		}
 	} else {
 		options := &session.Options{
@@ -191,7 +198,7 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 		sess, err = session.NewSessionWithOptions(*options)
 		if err != nil {
 			if IsAWSErr(err, "NoCredentialProviders", "") {
-				return nil, errors.New(errMsgNoValidCredentialSources)
+				return nil, ErrNoValidCredentialSources
 			}
 			return nil, fmt.Errorf("Error creating AWS session: %s", err)
 		}
@@ -200,7 +207,7 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 	creds := sess.Config.Credentials
 	cp, err := sess.Config.Credentials.Get()
 	if err != nil {
-		return nil, errors.New(errMsgNoValidCredentialSources)
+		return nil, ErrNoValidCredentialSources
 	}
 
 	log.Printf("[INFO] Successfully derived credentials from session")

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -423,20 +422,12 @@ func TestAWSGetCredentials_shouldErrorWhenBlank(t *testing.T) {
 	defer resetEnv()
 
 	cfg := Config{}
-	c, err := GetCredentials(&cfg)
+	_, err := GetCredentials(&cfg)
 
-	if err != nil {
+	if err != ErrNoValidCredentialSources {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	_, err = c.Get()
-	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() != "NoCredentialProviders" {
-			t.Fatal("Expected NoCredentialProviders error")
-		}
-	} else {
-		t.Fatal("Expected AWS error")
-	}
 	if err == nil {
 		t.Fatal("Expected an error given empty env, keys, and IAM in AWS Config")
 	}
@@ -586,21 +577,13 @@ func TestAWSGetCredentials_shouldErrorWithInvalidEndpoint(t *testing.T) {
 	ts := invalidAwsEnv(t)
 	defer ts()
 
-	creds, err := GetCredentials(&Config{})
-	if err != nil {
+	_, err := GetCredentials(&Config{})
+	if err != ErrNoValidCredentialSources {
 		t.Fatalf("Error gettings creds: %s", err)
 	}
-	if creds == nil {
-		t.Fatal("Expected a static creds provider to be returned")
-	}
 
-	v, err := creds.Get()
 	if err == nil {
 		t.Fatal("Expected error returned when getting creds w/ invalid EC2 endpoint")
-	}
-
-	if v.ProviderName != "" {
-		t.Fatalf("Expected provider name to be empty, %q given", v.ProviderName)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 	golang.org/x/text v0.3.0 // indirect
 )
+
+go 1.13

--- a/session.go
+++ b/session.go
@@ -28,45 +28,14 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 		},
 	}
 
+	// get and validate credentials
 	creds, err := GetCredentials(c)
 	if err != nil {
 		return nil, err
 	}
 
-	// Call Get to check for credential provider. If nothing found, we'll get an
-	// error, and we can present it nicely to the user
-	cp, err := creds.Get()
-	if err != nil {
-		if IsAWSErr(err, "NoCredentialProviders", "") {
-			// If a profile wasn't specified, the session may still be able to resolve credentials from shared config.
-			if c.Profile == "" {
-				sess, err := session.NewSession()
-				if err != nil {
-					return nil, errors.New(`No valid credential sources found for AWS Provider.
-	Please see https://terraform.io/docs/providers/aws/index.html for more information on
-	providing credentials for the AWS Provider`)
-				}
-				_, err = sess.Config.Credentials.Get()
-				if err != nil {
-					return nil, errors.New(`No valid credential sources found for AWS Provider.
-	Please see https://terraform.io/docs/providers/aws/index.html for more information on
-	providing credentials for the AWS Provider`)
-				}
-				log.Printf("[INFO] Using session-derived AWS Auth")
-				options.Config.Credentials = sess.Config.Credentials
-			} else {
-				log.Printf("[INFO] AWS Auth using Profile: %q", c.Profile)
-				options.Profile = c.Profile
-				options.SharedConfigState = session.SharedConfigEnable
-			}
-		} else {
-			return nil, fmt.Errorf("Error loading credentials for AWS Provider: %s", err)
-		}
-	} else {
-		// add the validated credentials to the session options
-		log.Printf("[INFO] AWS Auth provider used: %q", cp.ProviderName)
-		options.Config.Credentials = creds
-	}
+	// add the validated credentials to the session options
+	options.Config.Credentials = creds
 
 	if c.Insecure {
 		transport := options.Config.HTTPClient.Transport.(*http.Transport)
@@ -83,7 +52,7 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 	return options, nil
 }
 
-// GetSession attempts to return valid AWS Go SDK session
+// GetSession attempts to return valid AWS Go SDK session.
 func GetSession(c *Config) (*session.Session, error) {
 	options, err := GetSessionOptions(c)
 
@@ -94,9 +63,7 @@ func GetSession(c *Config) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
 		if IsAWSErr(err, "NoCredentialProviders", "") {
-			return nil, errors.New(`No valid credential sources found for AWS Provider.
-  Please see https://terraform.io/docs/providers/aws/index.html for more information on
-  providing credentials for the AWS Provider`)
+			return nil, errors.New(errMsgNoValidCredentialSources)
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %s", err)
 	}
@@ -138,7 +105,7 @@ func GetSession(c *Config) (*session.Session, error) {
 	if !c.SkipCredsValidation {
 		stsClient := sts.New(sess.Copy(&aws.Config{Endpoint: aws.String(c.StsEndpoint)}))
 		if _, _, err := GetAccountIDAndPartitionFromSTSGetCallerIdentity(stsClient); err != nil {
-			return nil, fmt.Errorf("error validating provider credentials: %s", err)
+			return nil, fmt.Errorf("error using credentials to get account ID: %s", err)
 		}
 	}
 

--- a/session.go
+++ b/session.go
@@ -2,7 +2,6 @@ package awsbase
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -63,7 +62,7 @@ func GetSession(c *Config) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
 		if IsAWSErr(err, "NoCredentialProviders", "") {
-			return nil, errors.New(errMsgNoValidCredentialSources)
+			return nil, ErrNoValidCredentialSources
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %s", err)
 	}


### PR DESCRIPTION
Fixes #4 

**Cleans up credential obtaining logic.**

NOTE: I contributed the [credential process provider](https://github.com/aws/aws-sdk-go/pull/2217) to the underlying AWS SDK Go.

Proposal:
* Ensure creds obtained (e.g., session-derived) _before_ attempting to assume role
* Update `GetCredentials()` contract so that creds are retrieved _and_ validated - simplifying logic in `GetSession()` and `GetSessionOptions()`.

Currently, the bug prevents fall-back creds (e.g., session-derived) from being used when assuming a role since session-derived creds are not obtained until _after_ the assume role logic. As a result, these circumstances will always result in failure to use credentials even when they are valid.

This PR fixes the bug.

In this PR, `GetCredentials()` has a new contract - it provides and validates credentials. Before, `GetCredentials()` would sometimes return unvalidated creds and sometimes validated creds. This meant that more error handling logic needed to be included in `GetSession()` and `GetSessionOptions()`. As part of validating creds, `GetCredentials()` now gets session-derived creds, if necessary, prior to assuming a role.

Related/possibly also fixed:
* terraform-providers/terraform-provider-aws#8242
* terraform-providers/terraform-provider-aws#8052
* terraform-providers/terraform-provider-aws#6566
* terraform-providers/terraform-provider-aws#6424
* terraform-providers/terraform-provider-aws#5592
* terraform-providers/terraform-provider-aws#2420
* terraform-providers/terraform-provider-aws#5251
* terraform-providers/terraform-provider-aws#5078
* terraform-providers/terraform-provider-aws#5018
