### PR TITLE
awsauth: Enable ECS credential provider when AWS_CONTAINER_CREDENTIALS_FULL_URI env var is defined

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -197,6 +197,9 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	if uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); len(uri) > 0 {
 		providers = append(providers, defaults.RemoteCredProvider(*cfg, defaults.Handlers()))
 		log.Print("[INFO] ECS container credentials detected, RemoteCredProvider added to auth chain")
+	} else if uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"); len(uri) > 0 {
+		providers = append(providers, defaults.RemoteCredProvider(*cfg, defaults.Handlers()))
+		log.Print("[INFO] ECS container credentials detected, RemoteCredProvider added to auth chain")
 	}
 
 	if !c.SkipMetadataApiCheck {


### PR DESCRIPTION
This improves credential provider compatibility with the AWS SDK.

See: https://github.com/aws/aws-sdk-go/blob/16cef773033e77d97f42fa5655c13bace6b9edc7/aws/defaults/defaults.go#L115-L133