### PR TITLE
Remove unnecessary closing paren in error message

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -24,7 +24,7 @@ func ValidateAccountID(accountID string, allowedAccountIDs, forbiddenAccountIDs 
 			}
 		}
 
-		return fmt.Errorf("AWS Account ID not allowed: %s)", accountID)
+		return fmt.Errorf("AWS Account ID not allowed: %s", accountID)
 	}
 
 	return nil


### PR DESCRIPTION
This leads to confusing error messages like:

```
Error: AWS Account ID not allowed: 000000000000)
```

where it tricks you into thinking there is a typo somewhere in your code that is injecting a `)`.