### PR TITLE
[WIP] Set 'aws.Config.CredentialsChainVerboseErrors' to true if DebugLogging

### DIFF
--- a/session.go
+++ b/session.go
@@ -22,9 +22,10 @@ import (
 func GetSessionOptions(c *Config) (*session.Options, error) {
 	options := &session.Options{
 		Config: aws.Config{
-			HTTPClient: cleanhttp.DefaultClient(),
-			MaxRetries: aws.Int(0),
-			Region:     aws.String(c.Region),
+			CredentialsChainVerboseErrors: aws.Bool(c.DebugLogging),
+			HTTPClient:                    cleanhttp.DefaultClient(),
+			MaxRetries:                    aws.Int(0),
+			Region:                        aws.String(c.Region),
 		},
 	}
 


### PR DESCRIPTION
Would help with debugging some of the Terraform AWS Provider issues such as https://github.com/terraform-providers/terraform-provider-aws/issues/9999.