### PR TITLE
Remove unnecessary parenthesis in error log

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -24,7 +24,7 @@ func ValidateAccountID(accountID string, allowedAccountIDs, forbiddenAccountIDs 
 			}
 		}
 
-		return fmt.Errorf("AWS Account ID not allowed: %s)", accountID)
+		return fmt.Errorf("AWS Account ID not allowed: %s", accountID)
 	}
 
 	return nil


### PR DESCRIPTION
Would make debugging 'AWS Account ID not allowed' errors easier. 

As it stands, it seems as if the closing parenthesis was provided as part of the account number which can be misleading.