### PR TITLE
Feature/fix cred chain

### DIFF
--- a/session.go
+++ b/session.go
@@ -25,6 +25,7 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 			MaxRetries: aws.Int(0),
 			Region:     aws.String(c.Region),
 		},
+		Profile: c.Profile,
 	}
 
 	// get and validate credentials


### PR DESCRIPTION
Proposal to fix issues like:
https://github.com/hashicorp/aws-sdk-go-base/issues/7
https://github.com/terraform-providers/terraform-provider-aws/issues/5018

The recent introduction of session-derived credentials from the AWS SDK was a huge improvement to searching the supported methods of loading credentials. However that code path was only being exercised on error, after validation of the original credential chain. In ECS and EC2 environments, this would never produce an error, so long as the metadata service returned its default credentials. The end result was to ignore the contents of any ~/.aws/config file, which is an important method of introducing other options (assume_role, etc). The root cause is also well documented in #7 

To fix, I have moved the ECS and EC2 metadata credentials fetching to the end of the validation chain. This allows the proper use of credentials_source = EcsContainer or EC2InstanceMetadata in earlier paths for loading credentials, and eliminates need to use the skip_metadata_api_check workaround when in EC2.

I've also included a fix for #19 

Fix order for credentials chain, building upon Dirk Avery's work.

    * Credential chain validation will now try, in order:
        - static variables
        - environment variables
        - shared credentials file
        - AWS SDK session-derived credentials (including shared config file)
        - ECS and EC2 metadata agents
    * Previous behavior ignored the config file when running in ECS/EC2,
      because those credentials would prematurely satisfy the contract.
      This prevented the use of config file options, in particular
      credentials_source = EcsContainer or EC2InstanceMetadata

Add missing profile #19 

