### PR TITLE
Introduce settings flag to stop execution if expired credentials error happen

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	StsEndpoint                 string
 	Token                       string
 	UserAgentProducts           []*UserAgentProduct
+	StopOnExpiredCreds          bool
 }
 
 type UserAgentProduct struct {


### PR DESCRIPTION
Changes proposed in this pull request:

Introduce new settings parameter to stop retrying if AWS credentials are expired. To keep existing behavior (retry MaxRetries times) defaulted to false