### PR TITLE
Update messaging, it is used in the backend also

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -24,9 +24,9 @@ import (
 
 const (
 	// errMsgNoValidCredentialSources error getting credentials
-	errMsgNoValidCredentialSources = `No valid credential sources found for AWS Provider.
+	errMsgNoValidCredentialSources = `No valid credential sources found for AWS.
 	Please see https://terraform.io/docs/providers/aws/index.html for more information on
-	providing credentials for the AWS Provider`
+	providing credentials for the AWS Provider and Backend.`
 )
 
 var (

--- a/session_test.go
+++ b/session_test.go
@@ -135,7 +135,7 @@ func TestGetSessionWithAccountIDAndPartition(t *testing.T) {
 			Region:            "us-west-2",
 			UserAgentProducts: []*UserAgentProduct{{}},
 			StsEndpoint:       ts.URL},
-			"", "", "No valid credential sources found for AWS Provider."},
+			"", "", "No valid credential sources found for AWS."},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Related to terraform-providers/terraform-provider-aws#13057, its unclear, since this is a common depenedency, whether this is for a provider or backend, when it could be both. Modifying the messaging here to make that a little more obvious. Ideally we should just make downstream consumers wrap these errors.