### PR TITLE
Additional AWS error functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.6.0 (unreleased)
+
+BREAKING CHANGES
+
+* AWS error checking function have been moved to `tfawserr` package. `IsAWSErr` has been renamed to `ErrMessageContains` and `IsAWSErrExtended` has been renamed to `ErrMessageAndOrigErrContain`. #37
+
+ENHANCEMENTS
+
+* Additional AWS error checking function have been added to the `tfawserr` package - `ErrCodeEquals`, `ErrCodeContains` and `ErrStatusCodeEquals`.
+
 # v0.5.0 (June 4, 2020)
 
 BREAKING CHANGES

--- a/awsauth.go
+++ b/awsauth.go
@@ -17,10 +17,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 )
 
 const (

--- a/awsauth.go
+++ b/awsauth.go
@@ -184,7 +184,7 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrCodeEquals(err, "NoCredentialProviders") {
 			return nil, c.NewNoValidCredentialSourcesError(err)
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %w", err)
@@ -230,7 +230,7 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	creds := awsCredentials.NewChainCredentials(providers)
 	cp, err := creds.Get()
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrCodeEquals(err, "NoCredentialProviders") {
 			creds, err = GetCredentialsFromSession(c)
 			if err != nil {
 				return nil, err

--- a/awsauth.go
+++ b/awsauth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 )
 
 const (
@@ -183,7 +184,7 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
-		if IsAWSErr(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
 			return nil, c.NewNoValidCredentialSourcesError(err)
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %w", err)
@@ -229,7 +230,7 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	creds := awsCredentials.NewChainCredentials(providers)
 	cp, err := creds.Get()
 	if err != nil {
-		if IsAWSErr(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
 			creds, err = GetCredentialsFromSession(c)
 			if err != nil {
 				return nil, err

--- a/awserr.go
+++ b/awserr.go
@@ -74,6 +74,8 @@ func IsAWSErrCodeMessageContains(err error, code string, message string) bool {
 // IsAWSErrRequestFailureStatusCode returns true if the error matches all these conditions:
 //  * err is of type awserr.RequestFailure
 //  * RequestFailure.StatusCode() equals statusCode
+// It is always preferable to use IsAWSErr() except in older APIs (e.g. S3)
+// that sometimes only respond with status codes.
 func IsAWSErrRequestFailureStatusCode(err error, statusCode int) bool {
 	var awsErr awserr.RequestFailure
 	if errors.As(err, &awsErr) {

--- a/awserr.go
+++ b/awserr.go
@@ -7,19 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-// IsAWSErr returns true if the error matches all these conditions:
-//  * err is of type awserr.Error
-//  * Error.Code() matches code
-//  * Error.Message() contains message
-func IsAWSErr(err error, code string, message string) bool {
-	var awsErr awserr.Error
-
-	if errors.As(err, &awsErr) {
-		return awsErr.Code() == code && strings.Contains(awsErr.Message(), message)
-	}
-
-	return false
-}
+var (
+	// IsAWSErr returns true if the error matches all these conditions:
+	//  * err is of type awserr.Error
+	//  * Error.Code() matches code
+	//  * Error.Message() contains message
+	IsAWSErr = IsAWSErrCodeMessageContains
+)
 
 // IsAWSErrExtended returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
@@ -40,5 +34,50 @@ func IsAWSErrExtended(err error, code string, message string, origErrMessage str
 		return strings.Contains(origErr.Error(), origErrMessage)
 	}
 
+	return false
+}
+
+// IsAWSErrCode returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() equals code
+func IsAWSErrCode(err error, code string) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == code
+	}
+	return false
+}
+
+// IsAWSErrCodeContains returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() contains code
+func IsAWSErrCodeContains(err error, code string) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return strings.Contains(awsErr.Code(), code)
+	}
+	return false
+}
+
+// IsAWSErrCodeMessageContains returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() equals code
+//  * Error.Message() contains message
+func IsAWSErrCodeMessageContains(err error, code string, message string) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == code && strings.Contains(awsErr.Message(), message)
+	}
+	return false
+}
+
+// IsAWSErrRequestFailureStatusCode returns true if the error matches all these conditions:
+//  * err is of type awserr.RequestFailure
+//  * RequestFailure.StatusCode() equals statusCode
+func IsAWSErrRequestFailureStatusCode(err error, statusCode int) bool {
+	var awsErr awserr.RequestFailure
+	if errors.As(err, &awsErr) {
+		return awsErr.StatusCode() == statusCode
+	}
 	return false
 }

--- a/awserr_test.go
+++ b/awserr_test.go
@@ -476,6 +476,8 @@ func TestIsAwsErrCode(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsAWSErrCode(testCase.Err, testCase.Code)
 
@@ -567,6 +569,8 @@ func TestIsAwsErrCodeContains(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsAWSErrCodeContains(testCase.Err, testCase.Code)
 
@@ -738,6 +742,8 @@ func TestIsAWSErrCodeMessageContains(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsAWSErrCodeMessageContains(testCase.Err, testCase.Code, testCase.Message)
 
@@ -807,6 +813,8 @@ func TestIsAWSErrRequestFailureStatusCode(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsAWSErrRequestFailureStatusCode(testCase.Err, testCase.StatusCode)
 

--- a/awserr_test.go
+++ b/awserr_test.go
@@ -408,3 +408,411 @@ func TestIsAwsErrExtended(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAwsErrCode(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Code     string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "nil error code",
+			Err:  nil,
+			Code: "test",
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name: "other error code",
+			Err:  errors.New("test"),
+			Code: "test",
+		},
+		{
+			Name:     "awserr error matching code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name: "awserr error no code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+		},
+		{
+			Name: "awserr error non-matching code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+			Code: "NotMatching",
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped other error code",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+			Code: "test",
+		},
+		{
+			Name:     "wrapped awserr error matching code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name: "wrapped awserr error no code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+		},
+		{
+			Name: "wrapped awserr error non-matching code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code: "NotMatching",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsAWSErrCode(testCase.Err, testCase.Code)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsAwsErrCodeContains(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Code     string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "nil error code",
+			Err:  nil,
+			Code: "test",
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name: "other error code",
+			Err:  errors.New("test"),
+			Code: "test",
+		},
+		{
+			Name:     "awserr error matching code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error contains code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "Test",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error no code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Expected: true,
+		},
+		{
+			Name: "awserr error non-matching code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+			Code: "NotMatching",
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped other error code",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+			Code: "test",
+		},
+		{
+			Name:     "wrapped awserr error matching code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error contains code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "Test",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error no code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Expected: true,
+		},
+		{
+			Name: "wrapped awserr error non-matching code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code: "NotMatching",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsAWSErrCodeContains(testCase.Err, testCase.Code)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsAWSErrCodeMessageContains(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Code     string
+		Message  string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name: "nil error code",
+			Err:  nil,
+			Code: "test",
+		},
+		{
+			Name:    "nil error message",
+			Err:     nil,
+			Message: "test",
+		},
+		{
+			Name:    "nil error code and message",
+			Err:     nil,
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name: "other error code",
+			Err:  errors.New("test"),
+			Code: "test",
+		},
+		{
+			Name:    "other error message",
+			Err:     errors.New("test"),
+			Message: "test",
+		},
+		{
+			Name:    "other error code and message",
+			Err:     errors.New("test"),
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name:     "awserr error matching code and no message",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error matching code and matching message exact",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		{
+			Name:     "awserr error matching code and matching message contains",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Code:     "TestCode",
+			Message:  "Message",
+			Expected: true,
+		},
+		{
+			Name:    "awserr error matching code and non-matching message",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		{
+			Name: "awserr error no code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+		},
+		{
+			Name:    "awserr error no code and matching message exact",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Message: "TestMessage",
+		},
+		{
+			Name: "awserr error non-matching code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+			Code: "NotMatching",
+		},
+		{
+			Name:    "awserr error non-matching code and message exact",
+			Err:     awserr.New("TestCode", "TestMessage", nil),
+			Message: "TestMessage",
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name: "wrapped other error code",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+			Code: "test",
+		},
+		{
+			Name:    "wrapped other error message",
+			Err:     fmt.Errorf("test: %w", errors.New("test")),
+			Message: "test",
+		},
+		{
+			Name:    "wrapped other error code and message",
+			Err:     fmt.Errorf("test: %w", errors.New("test")),
+			Code:    "test",
+			Message: "test",
+		},
+		{
+			Name:     "wrapped awserr error matching code and no message",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error matching code and matching message exact",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error matching code and matching message contains",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:     "TestCode",
+			Message:  "Message",
+			Expected: true,
+		},
+		{
+			Name:    "wrapped awserr error matching code and non-matching message",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		{
+			Name: "wrapped awserr error no code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+		},
+		{
+			Name:    "wrapped awserr error no code and matching message exact",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Message: "TestMessage",
+		},
+		{
+			Name: "wrapped awserr error non-matching code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Code: "NotMatching",
+		},
+		{
+			Name:    "wrapped awserr error non-matching code and message exact",
+			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Message: "TestMessage",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsAWSErrCodeMessageContains(testCase.Err, testCase.Code, testCase.Message)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsAWSErrRequestFailureStatusCode(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		Err        error
+		StatusCode int
+		Expected   bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name:       "nil error status code",
+			Err:        nil,
+			StatusCode: 42,
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:       "other error status code",
+			Err:        errors.New("test"),
+			StatusCode: 42,
+		},
+		{
+			Name:       "awserr error matching status code",
+			Err:        awserr.NewRequestFailure(awserr.New("TestCode", "TestMessage", nil), 42, ""),
+			StatusCode: 42,
+			Expected:   true,
+		},
+		{
+			Name:       "awserr error non-matching statuc code",
+			Err:        awserr.NewRequestFailure(awserr.New("TestCode", "TestMessage", nil), 404, ""),
+			StatusCode: 42,
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name:       "wrapped other status code",
+			Err:        fmt.Errorf("test: %w", errors.New("test")),
+			StatusCode: 42,
+		},
+		{
+			Name:       "wrapped awserr error matching status code",
+			Err:        fmt.Errorf("test: %w", awserr.NewRequestFailure(awserr.New("TestCode", "TestMessage", nil), 42, "")),
+			StatusCode: 42,
+			Expected:   true,
+		},
+		{
+			Name:       "wrapped awserr error non-matching status code",
+			Err:        fmt.Errorf("test: %w", awserr.NewRequestFailure(awserr.New("TestCode", "TestMessage", nil), 404, "")),
+			StatusCode: 42,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsAWSErrRequestFailureStatusCode(testCase.Err, testCase.StatusCode)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}

--- a/session.go
+++ b/session.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 const (

--- a/session.go
+++ b/session.go
@@ -79,7 +79,7 @@ func GetSession(c *Config) (*session.Session, error) {
 
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
-		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrCodeEquals(err, "NoCredentialProviders") {
 			return nil, c.NewNoValidCredentialSourcesError(err)
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %w", err)

--- a/session.go
+++ b/session.go
@@ -105,13 +105,13 @@ func GetSession(c *Config) (*session.Session, error) {
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp: lookup FQDN: no such host
-		if tfawserr.ErrMessageAndOrigErrContains(r.Error, "RequestError", "send request failed", "no such host") {
+		if tfawserr.ErrMessageAndOrigErrContain(r.Error, "RequestError", "send request failed", "no such host") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp IPADDRESS:443: connect: connection refused
-		if tfawserr.ErrMessageAndOrigErrContains(r.Error, "RequestError", "send request failed", "connection refused") {
+		if tfawserr.ErrMessageAndOrigErrContain(r.Error, "RequestError", "send request failed", "connection refused") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}

--- a/session.go
+++ b/session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 )
 
 const (
@@ -78,7 +79,7 @@ func GetSession(c *Config) (*session.Session, error) {
 
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
-		if IsAWSErr(err, "NoCredentialProviders", "") {
+		if tfawserr.ErrMessageContains(err, "NoCredentialProviders", "") {
 			return nil, c.NewNoValidCredentialSourcesError(err)
 		}
 		return nil, fmt.Errorf("Error creating AWS session: %w", err)
@@ -104,13 +105,13 @@ func GetSession(c *Config) (*session.Session, error) {
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp: lookup FQDN: no such host
-		if IsAWSErrExtended(r.Error, "RequestError", "send request failed", "no such host") {
+		if tfawserr.ErrMessageAndOrigErrContains(r.Error, "RequestError", "send request failed", "no such host") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp IPADDRESS:443: connect: connection refused
-		if IsAWSErrExtended(r.Error, "RequestError", "send request failed", "connection refused") {
+		if tfawserr.ErrMessageAndOrigErrContains(r.Error, "RequestError", "send request failed", "connection refused") {
 			log.Printf("[WARN] Disabling retries after next request due to networking issue")
 			r.Retryable = aws.Bool(false)
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/endpointcreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/hashicorp/aws-sdk-go-base/tfawserr"
 )
 
 func TestGetSessionOptions(t *testing.T) {
@@ -906,7 +907,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			},
 			Description: "credential validation error",
 			ExpectedError: func(err error) bool {
-				return IsAWSErr(err, "AccessDenied", "")
+				return tfawserr.ErrMessageContains(err, "AccessDenied", "")
 			},
 			MockStsEndpoints: []*MockEndpoint{
 				{
@@ -922,7 +923,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			},
 			Description: "session creation error",
 			ExpectedError: func(err error) bool {
-				return IsAWSErr(err, "CredentialRequiresARNError", "")
+				return tfawserr.ErrMessageContains(err, "CredentialRequiresARNError", "")
 			},
 			SharedConfigurationFile: `
 [profile SharedConfigurationProfile]

--- a/session_test.go
+++ b/session_test.go
@@ -907,7 +907,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			},
 			Description: "credential validation error",
 			ExpectedError: func(err error) bool {
-				return tfawserr.ErrMessageContains(err, "AccessDenied", "")
+				return tfawserr.ErrCodeEquals(err, "AccessDenied")
 			},
 			MockStsEndpoints: []*MockEndpoint{
 				{
@@ -923,7 +923,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			},
 			Description: "session creation error",
 			ExpectedError: func(err error) bool {
-				return tfawserr.ErrMessageContains(err, "CredentialRequiresARNError", "")
+				return tfawserr.ErrCodeEquals(err, "CredentialRequiresARNError")
 			},
 			SharedConfigurationFile: `
 [profile SharedConfigurationProfile]

--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -7,12 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-// ErrMessageAndOrigErrContains returns true if the error matches all these conditions:
+// ErrMessageAndOrigErrContain returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() matches code
 //  * Error.Message() contains message
 //  * Error.OrigErr() contains origErrMessage
-func ErrMessageAndOrigErrContains(err error, code string, message string, origErrMessage string) bool {
+func ErrMessageAndOrigErrContain(err error, code string, message string, origErrMessage string) bool {
 	if !ErrMessageContains(err, code, message) {
 		return false
 	}

--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -1,4 +1,4 @@
-package awsbase
+package tfawserr
 
 import (
 	"errors"
@@ -7,21 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-var (
-	// IsAWSErr returns true if the error matches all these conditions:
-	//  * err is of type awserr.Error
-	//  * Error.Code() matches code
-	//  * Error.Message() contains message
-	IsAWSErr = IsAWSErrCodeMessageContains
-)
-
-// IsAWSErrExtended returns true if the error matches all these conditions:
+// ErrMessageAndOrigErrContains returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() matches code
 //  * Error.Message() contains message
 //  * Error.OrigErr() contains origErrMessage
-func IsAWSErrExtended(err error, code string, message string, origErrMessage string) bool {
-	if !IsAWSErr(err, code, message) {
+func ErrMessageAndOrigErrContains(err error, code string, message string, origErrMessage string) bool {
+	if !ErrMessageContains(err, code, message) {
 		return false
 	}
 
@@ -37,10 +29,10 @@ func IsAWSErrExtended(err error, code string, message string, origErrMessage str
 	return false
 }
 
-// IsAWSErrCode returns true if the error matches all these conditions:
+// ErrCodeEquals returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() equals code
-func IsAWSErrCode(err error, code string) bool {
+func ErrCodeEquals(err error, code string) bool {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		return awsErr.Code() == code
@@ -48,10 +40,10 @@ func IsAWSErrCode(err error, code string) bool {
 	return false
 }
 
-// IsAWSErrCodeContains returns true if the error matches all these conditions:
+// ErrCodeContains returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() contains code
-func IsAWSErrCodeContains(err error, code string) bool {
+func ErrCodeContains(err error, code string) bool {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		return strings.Contains(awsErr.Code(), code)
@@ -59,11 +51,11 @@ func IsAWSErrCodeContains(err error, code string) bool {
 	return false
 }
 
-// IsAWSErrCodeMessageContains returns true if the error matches all these conditions:
+// ErrMessageContains returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() equals code
 //  * Error.Message() contains message
-func IsAWSErrCodeMessageContains(err error, code string, message string) bool {
+func ErrMessageContains(err error, code string, message string) bool {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		return awsErr.Code() == code && strings.Contains(awsErr.Message(), message)
@@ -71,12 +63,12 @@ func IsAWSErrCodeMessageContains(err error, code string, message string) bool {
 	return false
 }
 
-// IsAWSErrRequestFailureStatusCode returns true if the error matches all these conditions:
+// ErrStatusCodeEquals returns true if the error matches all these conditions:
 //  * err is of type awserr.RequestFailure
 //  * RequestFailure.StatusCode() equals statusCode
-// It is always preferable to use IsAWSErr() except in older APIs (e.g. S3)
+// It is always preferable to use ErrMessageContains() except in older APIs (e.g. S3)
 // that sometimes only respond with status codes.
-func IsAWSErrRequestFailureStatusCode(err error, statusCode int) bool {
+func ErrStatusCodeEquals(err error, statusCode int) bool {
 	var awsErr awserr.RequestFailure
 	if errors.As(err, &awsErr) {
 		return awsErr.StatusCode() == statusCode

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -1,4 +1,4 @@
-package awsbase
+package tfawserr
 
 import (
 	"errors"
@@ -8,180 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func TestIsAwsErr(t *testing.T) {
-	testCases := []struct {
-		Name     string
-		Err      error
-		Code     string
-		Message  string
-		Expected bool
-	}{
-		{
-			Name: "nil error",
-			Err:  nil,
-		},
-		{
-			Name: "nil error code",
-			Err:  nil,
-			Code: "test",
-		},
-		{
-			Name:    "nil error message",
-			Err:     nil,
-			Message: "test",
-		},
-		{
-			Name:    "nil error code and message",
-			Err:     nil,
-			Code:    "test",
-			Message: "test",
-		},
-		{
-			Name: "other error",
-			Err:  errors.New("test"),
-		},
-		{
-			Name: "other error code",
-			Err:  errors.New("test"),
-			Code: "test",
-		},
-		{
-			Name:    "other error message",
-			Err:     errors.New("test"),
-			Message: "test",
-		},
-		{
-			Name:    "other error code and message",
-			Err:     errors.New("test"),
-			Code:    "test",
-			Message: "test",
-		},
-		{
-			Name:     "awserr error matching code and no message",
-			Err:      awserr.New("TestCode", "TestMessage", nil),
-			Code:     "TestCode",
-			Expected: true,
-		},
-		{
-			Name:     "awserr error matching code and matching message exact",
-			Err:      awserr.New("TestCode", "TestMessage", nil),
-			Code:     "TestCode",
-			Message:  "TestMessage",
-			Expected: true,
-		},
-		{
-			Name:     "awserr error matching code and matching message contains",
-			Err:      awserr.New("TestCode", "TestMessage", nil),
-			Code:     "TestCode",
-			Message:  "Message",
-			Expected: true,
-		},
-		{
-			Name:    "awserr error matching code and non-matching message",
-			Err:     awserr.New("TestCode", "TestMessage", nil),
-			Code:    "TestCode",
-			Message: "NotMatching",
-		},
-		{
-			Name: "awserr error no code",
-			Err:  awserr.New("TestCode", "TestMessage", nil),
-		},
-		{
-			Name:    "awserr error no code and matching message exact",
-			Err:     awserr.New("TestCode", "TestMessage", nil),
-			Message: "TestMessage",
-		},
-		{
-			Name: "awserr error non-matching code",
-			Err:  awserr.New("TestCode", "TestMessage", nil),
-			Code: "NotMatching",
-		},
-		{
-			Name:    "awserr error non-matching code and message exact",
-			Err:     awserr.New("TestCode", "TestMessage", nil),
-			Message: "TestMessage",
-		},
-		{
-			Name: "wrapped other error",
-			Err:  fmt.Errorf("test: %w", errors.New("test")),
-		},
-		{
-			Name: "wrapped other error code",
-			Err:  fmt.Errorf("test: %w", errors.New("test")),
-			Code: "test",
-		},
-		{
-			Name:    "wrapped other error message",
-			Err:     fmt.Errorf("test: %w", errors.New("test")),
-			Message: "test",
-		},
-		{
-			Name:    "wrapped other error code and message",
-			Err:     fmt.Errorf("test: %w", errors.New("test")),
-			Code:    "test",
-			Message: "test",
-		},
-		{
-			Name:     "wrapped awserr error matching code and no message",
-			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code:     "TestCode",
-			Expected: true,
-		},
-		{
-			Name:     "wrapped awserr error matching code and matching message exact",
-			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code:     "TestCode",
-			Message:  "TestMessage",
-			Expected: true,
-		},
-		{
-			Name:     "wrapped awserr error matching code and matching message contains",
-			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code:     "TestCode",
-			Message:  "Message",
-			Expected: true,
-		},
-		{
-			Name:    "wrapped awserr error matching code and non-matching message",
-			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code:    "TestCode",
-			Message: "NotMatching",
-		},
-		{
-			Name: "wrapped awserr error no code",
-			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-		},
-		{
-			Name:    "wrapped awserr error no code and matching message exact",
-			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Message: "TestMessage",
-		},
-		{
-			Name: "wrapped awserr error non-matching code",
-			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code: "NotMatching",
-		},
-		{
-			Name:    "wrapped awserr error non-matching code and message exact",
-			Err:     fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Message: "TestMessage",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErr(testCase.Err, testCase.Code, testCase.Message)
-
-			if got != testCase.Expected {
-				t.Errorf("got %t, expected %t", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-func TestIsAwsErrExtended(t *testing.T) {
+func TestErrMessageAndOrigErrContains(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		Err             error
@@ -400,7 +227,7 @@ func TestIsAwsErrExtended(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErrExtended(testCase.Err, testCase.Code, testCase.Message, testCase.ExtendedMessage)
+			got := ErrMessageAndOrigErrContains(testCase.Err, testCase.Code, testCase.Message, testCase.ExtendedMessage)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
@@ -409,7 +236,7 @@ func TestIsAwsErrExtended(t *testing.T) {
 	}
 }
 
-func TestIsAwsErrCode(t *testing.T) {
+func TestErrCodeEquals(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Err      error
@@ -479,7 +306,7 @@ func TestIsAwsErrCode(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErrCode(testCase.Err, testCase.Code)
+			got := ErrCodeEquals(testCase.Err, testCase.Code)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
@@ -488,7 +315,7 @@ func TestIsAwsErrCode(t *testing.T) {
 	}
 }
 
-func TestIsAwsErrCodeContains(t *testing.T) {
+func TestErrCodeContains(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Err      error
@@ -572,7 +399,7 @@ func TestIsAwsErrCodeContains(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErrCodeContains(testCase.Err, testCase.Code)
+			got := ErrCodeContains(testCase.Err, testCase.Code)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
@@ -581,7 +408,7 @@ func TestIsAwsErrCodeContains(t *testing.T) {
 	}
 }
 
-func TestIsAWSErrCodeMessageContains(t *testing.T) {
+func TestErrMessageContains(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Err      error
@@ -745,7 +572,7 @@ func TestIsAWSErrCodeMessageContains(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErrCodeMessageContains(testCase.Err, testCase.Code, testCase.Message)
+			got := ErrMessageContains(testCase.Err, testCase.Code, testCase.Message)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)
@@ -754,7 +581,7 @@ func TestIsAWSErrCodeMessageContains(t *testing.T) {
 	}
 }
 
-func TestIsAWSErrRequestFailureStatusCode(t *testing.T) {
+func TestErrStatusCodeEquals(t *testing.T) {
 	testCases := []struct {
 		Name       string
 		Err        error
@@ -816,7 +643,7 @@ func TestIsAWSErrRequestFailureStatusCode(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := IsAWSErrRequestFailureStatusCode(testCase.Err, testCase.StatusCode)
+			got := ErrStatusCodeEquals(testCase.Err, testCase.StatusCode)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
-func TestErrMessageAndOrigErrContains(t *testing.T) {
+func TestErrMessageAndOrigErrContain(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		Err             error
@@ -227,7 +227,7 @@ func TestErrMessageAndOrigErrContains(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := ErrMessageAndOrigErrContains(testCase.Err, testCase.Code, testCase.Message, testCase.ExtendedMessage)
+			got := ErrMessageAndOrigErrContain(testCase.Err, testCase.Code, testCase.Message, testCase.ExtendedMessage)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/terraform-providers/terraform-provider-aws/pull/13036.

Additional AWS error code functions used within the AWS Provider to be migrated here so that they can be used in other contexts.

Relevant unit tests:

```console
$ go test -v ./...
=== RUN   TestIsAwsErr
=== RUN   TestIsAwsErr/nil_error
=== RUN   TestIsAwsErr/nil_error_code
=== RUN   TestIsAwsErr/nil_error_message
=== RUN   TestIsAwsErr/nil_error_code_and_message
=== RUN   TestIsAwsErr/other_error
=== RUN   TestIsAwsErr/other_error_code
=== RUN   TestIsAwsErr/other_error_message
=== RUN   TestIsAwsErr/other_error_code_and_message
=== RUN   TestIsAwsErr/awserr_error_matching_code_and_no_message
=== RUN   TestIsAwsErr/awserr_error_matching_code_and_matching_message_exact
=== RUN   TestIsAwsErr/awserr_error_matching_code_and_matching_message_contains
=== RUN   TestIsAwsErr/awserr_error_matching_code_and_non-matching_message
=== RUN   TestIsAwsErr/awserr_error_no_code
=== RUN   TestIsAwsErr/awserr_error_no_code_and_matching_message_exact
=== RUN   TestIsAwsErr/awserr_error_non-matching_code
=== RUN   TestIsAwsErr/awserr_error_non-matching_code_and_message_exact
=== RUN   TestIsAwsErr/wrapped_other_error
=== RUN   TestIsAwsErr/wrapped_other_error_code
=== RUN   TestIsAwsErr/wrapped_other_error_message
=== RUN   TestIsAwsErr/wrapped_other_error_code_and_message
=== RUN   TestIsAwsErr/wrapped_awserr_error_matching_code_and_no_message
=== RUN   TestIsAwsErr/wrapped_awserr_error_matching_code_and_matching_message_exact
=== RUN   TestIsAwsErr/wrapped_awserr_error_matching_code_and_matching_message_contains
=== RUN   TestIsAwsErr/wrapped_awserr_error_matching_code_and_non-matching_message
=== RUN   TestIsAwsErr/wrapped_awserr_error_no_code
=== RUN   TestIsAwsErr/wrapped_awserr_error_no_code_and_matching_message_exact
=== RUN   TestIsAwsErr/wrapped_awserr_error_non-matching_code
=== RUN   TestIsAwsErr/wrapped_awserr_error_non-matching_code_and_message_exact
--- PASS: TestIsAwsErr (0.00s)
    --- PASS: TestIsAwsErr/nil_error (0.00s)
    --- PASS: TestIsAwsErr/nil_error_code (0.00s)
    --- PASS: TestIsAwsErr/nil_error_message (0.00s)
    --- PASS: TestIsAwsErr/nil_error_code_and_message (0.00s)
    --- PASS: TestIsAwsErr/other_error (0.00s)
    --- PASS: TestIsAwsErr/other_error_code (0.00s)
    --- PASS: TestIsAwsErr/other_error_message (0.00s)
    --- PASS: TestIsAwsErr/other_error_code_and_message (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_matching_code_and_no_message (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_matching_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_matching_code_and_matching_message_contains (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_matching_code_and_non-matching_message (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_no_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAwsErr/awserr_error_non-matching_code_and_message_exact (0.00s)
    --- PASS: TestIsAwsErr/wrapped_other_error (0.00s)
    --- PASS: TestIsAwsErr/wrapped_other_error_code (0.00s)
    --- PASS: TestIsAwsErr/wrapped_other_error_message (0.00s)
    --- PASS: TestIsAwsErr/wrapped_other_error_code_and_message (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_matching_code_and_no_message (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_matching_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_matching_code_and_matching_message_contains (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_matching_code_and_non-matching_message (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_no_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAwsErr/wrapped_awserr_error_non-matching_code_and_message_exact (0.00s)
=== RUN   TestIsAwsErrExtended
=== RUN   TestIsAwsErrExtended/nil_error
=== RUN   TestIsAwsErrExtended/nil_error_code
=== RUN   TestIsAwsErrExtended/nil_error_message
=== RUN   TestIsAwsErrExtended/nil_error_code_and_message
=== RUN   TestIsAwsErrExtended/nil_error_code,_message,_and_extended_message
=== RUN   TestIsAwsErrExtended/other_error
=== RUN   TestIsAwsErrExtended/other_error_code
=== RUN   TestIsAwsErrExtended/other_error_message
=== RUN   TestIsAwsErrExtended/other_error_code_and_message
=== RUN   TestIsAwsErrExtended/other_error_code,_message,_and_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_no_message,_and_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_exact,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_exact,_and_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_contains,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_contains,_and_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_non-matching_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_no_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_no_code,_matching_message_exact,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_non-matching_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_non-extended_error_non-matching_code,_matching_message_exact,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_matching_extended_message_exact
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_matching_extended_message_contains
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_matching_extended_message_exact
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_matching_extended_message_contains
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_contains,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_contains,_and_matching_extended_message_contains
=== RUN   TestIsAwsErrExtended/awserr_extended_error_matching_code,_non-matching_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_no_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_no_code,_matching_message_exact,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_non-matching_code,_no_message,_and_no_extended_message
=== RUN   TestIsAwsErrExtended/awserr_extended_error_non-matching_code,_matching_message_exact,_and_no_extended_message
--- PASS: TestIsAwsErrExtended (0.01s)
    --- PASS: TestIsAwsErrExtended/nil_error (0.00s)
    --- PASS: TestIsAwsErrExtended/nil_error_code (0.00s)
    --- PASS: TestIsAwsErrExtended/nil_error_message (0.00s)
    --- PASS: TestIsAwsErrExtended/nil_error_code_and_message (0.00s)
    --- PASS: TestIsAwsErrExtended/nil_error_code,_message,_and_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/other_error (0.00s)
    --- PASS: TestIsAwsErrExtended/other_error_code (0.00s)
    --- PASS: TestIsAwsErrExtended/other_error_message (0.00s)
    --- PASS: TestIsAwsErrExtended/other_error_code_and_message (0.00s)
    --- PASS: TestIsAwsErrExtended/other_error_code,_message,_and_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_no_message,_and_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_exact,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_exact,_and_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_contains,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_matching_message_contains,_and_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_matching_code,_non-matching_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_no_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_no_code,_matching_message_exact,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_non-matching_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_non-extended_error_non-matching_code,_matching_message_exact,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_matching_extended_message_exact (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_no_message,_and_matching_extended_message_contains (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_matching_extended_message_exact (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_exact,_and_matching_extended_message_contains (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_contains,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_matching_message_contains,_and_matching_extended_message_contains (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_matching_code,_non-matching_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_no_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_no_code,_matching_message_exact,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_non-matching_code,_no_message,_and_no_extended_message (0.00s)
    --- PASS: TestIsAwsErrExtended/awserr_extended_error_non-matching_code,_matching_message_exact,_and_no_extended_message (0.00s)
=== RUN   TestIsAwsErrCode
=== RUN   TestIsAwsErrCode/nil_error
=== RUN   TestIsAwsErrCode/nil_error_code
=== RUN   TestIsAwsErrCode/other_error
=== RUN   TestIsAwsErrCode/other_error_code
=== RUN   TestIsAwsErrCode/awserr_error_matching_code
=== RUN   TestIsAwsErrCode/awserr_error_no_code
=== RUN   TestIsAwsErrCode/awserr_error_non-matching_code
=== RUN   TestIsAwsErrCode/wrapped_other_error
=== RUN   TestIsAwsErrCode/wrapped_other_error_code
=== RUN   TestIsAwsErrCode/wrapped_awserr_error_matching_code
=== RUN   TestIsAwsErrCode/wrapped_awserr_error_no_code
=== RUN   TestIsAwsErrCode/wrapped_awserr_error_non-matching_code
--- PASS: TestIsAwsErrCode (0.00s)
    --- PASS: TestIsAwsErrCode/nil_error (0.00s)
    --- PASS: TestIsAwsErrCode/nil_error_code (0.00s)
    --- PASS: TestIsAwsErrCode/other_error (0.00s)
    --- PASS: TestIsAwsErrCode/other_error_code (0.00s)
    --- PASS: TestIsAwsErrCode/awserr_error_matching_code (0.00s)
    --- PASS: TestIsAwsErrCode/awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErrCode/awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAwsErrCode/wrapped_other_error (0.00s)
    --- PASS: TestIsAwsErrCode/wrapped_other_error_code (0.00s)
    --- PASS: TestIsAwsErrCode/wrapped_awserr_error_matching_code (0.00s)
    --- PASS: TestIsAwsErrCode/wrapped_awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErrCode/wrapped_awserr_error_non-matching_code (0.00s)
=== RUN   TestIsAwsErrCodeContains
=== RUN   TestIsAwsErrCodeContains/nil_error
=== RUN   TestIsAwsErrCodeContains/nil_error_code
=== RUN   TestIsAwsErrCodeContains/other_error
=== RUN   TestIsAwsErrCodeContains/other_error_code
=== RUN   TestIsAwsErrCodeContains/awserr_error_matching_code
=== RUN   TestIsAwsErrCodeContains/awserr_error_contains_code
=== RUN   TestIsAwsErrCodeContains/awserr_error_no_code
=== RUN   TestIsAwsErrCodeContains/awserr_error_non-matching_code
=== RUN   TestIsAwsErrCodeContains/wrapped_other_error
=== RUN   TestIsAwsErrCodeContains/wrapped_other_error_code
=== RUN   TestIsAwsErrCodeContains/wrapped_awserr_error_matching_code
=== RUN   TestIsAwsErrCodeContains/wrapped_awserr_error_contains_code
=== RUN   TestIsAwsErrCodeContains/wrapped_awserr_error_no_code
=== RUN   TestIsAwsErrCodeContains/wrapped_awserr_error_non-matching_code
--- PASS: TestIsAwsErrCodeContains (0.01s)
    --- PASS: TestIsAwsErrCodeContains/nil_error (0.00s)
    --- PASS: TestIsAwsErrCodeContains/nil_error_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/other_error (0.00s)
    --- PASS: TestIsAwsErrCodeContains/other_error_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/awserr_error_matching_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/awserr_error_contains_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_other_error (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_other_error_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_awserr_error_matching_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_awserr_error_contains_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_awserr_error_no_code (0.00s)
    --- PASS: TestIsAwsErrCodeContains/wrapped_awserr_error_non-matching_code (0.00s)
=== RUN   TestIsAWSErrCodeMessageContains
=== RUN   TestIsAWSErrCodeMessageContains/nil_error
=== RUN   TestIsAWSErrCodeMessageContains/nil_error_code
=== RUN   TestIsAWSErrCodeMessageContains/nil_error_message
=== RUN   TestIsAWSErrCodeMessageContains/nil_error_code_and_message
=== RUN   TestIsAWSErrCodeMessageContains/other_error
=== RUN   TestIsAWSErrCodeMessageContains/other_error_code
=== RUN   TestIsAWSErrCodeMessageContains/other_error_message
=== RUN   TestIsAWSErrCodeMessageContains/other_error_code_and_message
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_no_message
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_matching_message_exact
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_matching_message_contains
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_non-matching_message
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_no_code
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_no_code_and_matching_message_exact
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_non-matching_code
=== RUN   TestIsAWSErrCodeMessageContains/awserr_error_non-matching_code_and_message_exact
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_other_error
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_other_error_code
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_other_error_message
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_other_error_code_and_message
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_no_message
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_matching_message_exact
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_matching_message_contains
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_non-matching_message
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_no_code
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_no_code_and_matching_message_exact
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_non-matching_code
=== RUN   TestIsAWSErrCodeMessageContains/wrapped_awserr_error_non-matching_code_and_message_exact
--- PASS: TestIsAWSErrCodeMessageContains (0.01s)
    --- PASS: TestIsAWSErrCodeMessageContains/nil_error (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/nil_error_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/nil_error_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/nil_error_code_and_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/other_error (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/other_error_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/other_error_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/other_error_code_and_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_no_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_matching_message_contains (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_matching_code_and_non-matching_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_no_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_no_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/awserr_error_non-matching_code_and_message_exact (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_other_error (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_other_error_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_other_error_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_other_error_code_and_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_no_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_matching_message_contains (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_matching_code_and_non-matching_message (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_no_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_no_code_and_matching_message_exact (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_non-matching_code (0.00s)
    --- PASS: TestIsAWSErrCodeMessageContains/wrapped_awserr_error_non-matching_code_and_message_exact (0.00s)
=== RUN   TestIsAWSErrRequestFailureStatusCode
=== RUN   TestIsAWSErrRequestFailureStatusCode/nil_error
=== RUN   TestIsAWSErrRequestFailureStatusCode/nil_error_status_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/other_error
=== RUN   TestIsAWSErrRequestFailureStatusCode/other_error_status_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/awserr_error_matching_status_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/awserr_error_non-matching_statuc_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/wrapped_other_error
=== RUN   TestIsAWSErrRequestFailureStatusCode/wrapped_other_status_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/wrapped_awserr_error_matching_status_code
=== RUN   TestIsAWSErrRequestFailureStatusCode/wrapped_awserr_error_non-matching_status_code
--- PASS: TestIsAWSErrRequestFailureStatusCode (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/nil_error (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/nil_error_status_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/other_error (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/other_error_status_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/awserr_error_matching_status_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/awserr_error_non-matching_statuc_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/wrapped_other_error (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/wrapped_other_status_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/wrapped_awserr_error_matching_status_code (0.00s)
    --- PASS: TestIsAWSErrRequestFailureStatusCode/wrapped_awserr_error_non-matching_status_code (0.00s)
```
