### PR TITLE
Mock and verify Web Identity Token support (STS AssumeRoleWithWebIdentity)

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -216,6 +216,27 @@ const stsResponse_AssumeRole_InvalidClientTokenId = `<ErrorResponse xmlns="https
 <RequestId>4d0cf5ec-892a-4d3f-84e4-30e9987d9bdd</RequestId>
 </ErrorResponse>`
 
+var stsResponse_AssumeRoleWithWebIdentity_valid = fmt.Sprintf(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<AssumeRoleWithWebIdentityResult>
+  <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
+  <Audience>client.6666666666666666666.6666@apps.example.com</Audience>
+  <AssumedRoleUser>
+    <Arn>arn:aws:sts::666666666666:assumed-role/FederatedWebIdentityRole/AssumeRoleWithWebIdentitySessionName</Arn>
+    <AssumedRoleId>ARO123EXAMPLE123:AssumeRoleWithWebIdentitySessionName</AssumedRoleId>
+  </AssumedRoleUser>
+  <Credentials>
+    <SessionToken>AssumeRoleWithWebIdentitySessionToken</SessionToken>
+    <SecretAccessKey>AssumeRoleWithWebIdentitySecretKey</SecretAccessKey>
+    <Expiration>%s</Expiration>
+    <AccessKeyId>AssumeRoleWithWebIdentityAccessKey</AccessKeyId>
+  </Credentials>
+  <Provider>www.amazon.com</Provider>
+</AssumeRoleWithWebIdentityResult>
+<ResponseMetadata>
+  <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`, time.Now().UTC().Format(time.RFC3339))
+
 const stsResponse_GetCallerIdentity_valid = `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>
    <Arn>arn:aws:iam::222222222222:user/Alice</Arn>
@@ -279,3 +300,5 @@ const iamResponse_ListRoles_unauthorized = `<ErrorResponse xmlns="https://iam.am
   </Error>
   <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
 </ErrorResponse>`
+
+const webIdentityToken = `WebIdentityToken`

--- a/session_test.go
+++ b/session_test.go
@@ -66,6 +66,7 @@ func TestGetSession(t *testing.T) {
 		Description                string
 		EnableEc2MetadataServer    bool
 		EnableEcsCredentialsServer bool
+		EnableWebIdentityToken     bool
 		EnvironmentVariables       map[string]string
 		ExpectedCredentialsValue   credentials.Value
 		ExpectedRegion             string
@@ -532,6 +533,31 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			Config: &Config{
 				Region: "us-east-1",
 			},
+			Description:             "web identity token access key",
+			EnableEc2MetadataServer: true,
+			EnableWebIdentityToken:  true,
+			ExpectedCredentialsValue: credentials.Value{
+				AccessKeyID:     "AssumeRoleWithWebIdentityAccessKey",
+				ProviderName:    stscreds.WebIdentityProviderName,
+				SecretAccessKey: "AssumeRoleWithWebIdentitySecretKey",
+				SessionToken:    "AssumeRoleWithWebIdentitySessionToken",
+			},
+			ExpectedRegion: "us-east-1",
+			MockStsEndpoints: []*MockEndpoint{
+				{
+					Request:  &MockRequest{"POST", "/", "Action=AssumeRoleWithWebIdentity&RoleArn=arn%3Aaws%3Aiam%3A%3A666666666666%3Arole%2FWebIdentityToken&RoleSessionName=AssumeRoleWithWebIdentitySessionName&Version=2011-06-15&WebIdentityToken=WebIdentityToken"},
+					Response: &MockResponse{200, stsResponse_AssumeRoleWithWebIdentity_valid, "text/xml"},
+				},
+				{
+					Request:  &MockRequest{"POST", "/", "Action=GetCallerIdentity&Version=2011-06-15"},
+					Response: &MockResponse{200, stsResponse_GetCallerIdentity_valid, "text/xml"},
+				},
+			},
+		},
+		{
+			Config: &Config{
+				Region: "us-east-1",
+			},
 			Description:             "EC2 metadata access key",
 			EnableEc2MetadataServer: true,
 			ExpectedCredentialsValue: credentials.Value{
@@ -951,6 +977,26 @@ source_profile = SourceSharedCredentials
 			if testCase.EnableEcsCredentialsServer {
 				closeEcsCredentials := ecsCredentialsApiMock()
 				defer closeEcsCredentials()
+			}
+
+			if testCase.EnableWebIdentityToken {
+				file, err := ioutil.TempFile("", "aws-sdk-go-base-web-identity-token-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = ioutil.WriteFile(file.Name(), []byte(webIdentityToken), 0600)
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				os.Setenv("AWS_ROLE_ARN", "arn:aws:iam::666666666666:role/WebIdentityToken")
+				os.Setenv("AWS_ROLE_SESSION_NAME", "AssumeRoleWithWebIdentitySessionName")
+				os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", file.Name())
 			}
 
 			closeSts, mockStsSession, err := GetMockedAwsApiSession("STS", testCase.MockStsEndpoints)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #33

Add a mock STS `AssumeRoleWithWebIdentity` valid response, add helper flag to `TestGetSession()` to enable web identity token support (via its bespoke environment variables), and verify we get the proper credentials when that support is enabled.
