### PR TITLE
Fix SkipMetadataApiCheck and remove now extraneous GetCredentialsFromMetadata

### DIFF
--- a/session.go
+++ b/session.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -65,6 +66,10 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 
 // GetSession attempts to return valid AWS Go SDK session.
 func GetSession(c *Config) (*session.Session, error) {
+	if c.SkipMetadataApiCheck {
+		os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	}
+
 	options, err := GetSessionOptions(c)
 
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -922,7 +922,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			},
 			Description: "session creation error",
 			ExpectedError: func(err error) bool {
-				return IsAWSErr(err, "NoCredentialProviders", "")
+				return IsAWSErr(err, "CredentialRequiresARNError", "")
 			},
 			SharedConfigurationFile: `
 [profile SharedConfigurationProfile]
@@ -941,6 +941,18 @@ source_profile = SourceSharedCredentials
 				AccessKeyID:     "StaticAccessKey",
 				ProviderName:    credentials.StaticProviderName,
 				SecretAccessKey: "StaticSecretKey",
+			},
+			ExpectedRegion: "us-east-1",
+		},
+		{
+			Config: &Config{
+				Region:               "us-east-1",
+				SkipMetadataApiCheck: true,
+			},
+			Description:             "skip EC2 metadata API check",
+			EnableEc2MetadataServer: true,
+			ExpectedError: func(err error) bool {
+				return IsNoValidCredentialSourcesError(err)
 			},
 			ExpectedRegion: "us-east-1",
 		},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #43

`GetCredentialsFromMetadata` is superseded by default AWS Go SDK credential handling, which is now called beforehand.
