### PR TITLE
Add http proxy support as a config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	DebugLogging                bool
 	IamEndpoint                 string
 	Insecure                    bool
+	HTTPProxy                   string
 	MaxRetries                  int
 	Profile                     string
 	Region                      string

--- a/session.go
+++ b/session.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -50,11 +51,20 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 	// add the validated credentials to the session options
 	options.Config.Credentials = creds
 
+	transport := options.Config.HTTPClient.Transport.(*http.Transport)
 	if c.Insecure {
-		transport := options.Config.HTTPClient.Transport.(*http.Transport)
 		transport.TLSClientConfig = &tls.Config{
 			InsecureSkipVerify: true,
 		}
+	}
+
+	if c.HTTPProxy != "" {
+		proxyUrl, err := url.Parse(c.HTTPProxy)
+		if err != nil {
+			return nil, err
+		}
+
+		transport.Proxy = http.ProxyURL(proxyUrl)
 	}
 
 	if c.DebugLogging {

--- a/session.go
+++ b/session.go
@@ -61,7 +61,7 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 	if c.HTTPProxy != "" {
 		proxyUrl, err := url.Parse(c.HTTPProxy)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error parsing HTTP proxy URL: %w", err)
 		}
 
 		transport.Proxy = http.ProxyURL(proxyUrl)

--- a/session_test.go
+++ b/session_test.go
@@ -34,6 +34,14 @@ func TestGetSessionOptions(t *testing.T) {
 			&Config{AccessKey: "MockAccessKey", SecretKey: "MockSecretKey", Insecure: true, DebugLogging: true},
 			false,
 		},
+		{"ConfigWithHTTPProxy",
+			&Config{AccessKey: "MockAccessKey", SecretKey: "MockSecretKey", HTTPProxy: "https://127.0.0.1:8888"},
+			false,
+		},
+		{"ConfigWithHTTPBadProxy",
+			&Config{AccessKey: "MockAccessKey", SecretKey: "MockSecretKey", HTTPProxy: "127.0.0.1:8888"},
+			true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Some setups require the use of fine grained proxy settings (and cannot rely on environment variables alone). This PR enables this as a config option.

Cheers!

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: #0000 <!--- Pull Requests should have an associated issue or may be closed --->

Please briefly describe the changes proposed in this pull request.
