### PR TITLE
docs: Add Release Process section and note dependency on Go 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An opinionated [AWS Go SDK](https://github.com/aws/aws-sdk-go) library for consi
 
 ## Requirements
 
-- [Go](https://golang.org/doc/install) 1.12
+- [Go](https://golang.org/doc/install) 1.13
 
 ## Development
 
@@ -24,4 +24,16 @@ Code quality assurance uses [golangci-lint](https://github.com/golangci/golangci
 $ golangci-lint run ./...
 # Optionally if Make is available; both run the same linting
 $ make lint
+```
+
+## Release Process
+
+- Push a new `vX.Y.Z` tag to the repository
+- For Terraform AWS Provider: Renovate will automatically detect the update and submit a dependency pull request (usually within an hour)
+- For Terraform S3 Backend: Submit a new dependency pull request by running:
+
+```sh
+go get github.com/hashicorp/aws-sdk-go-base@vX.Y.Z
+go mod tidy
+go mod vendor
 ```


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Go dependency is due to our usage of the `%w` verb in `fmt.Errorf()` and noted already in the `go.mod` file.
