### PR TITLE
[DOCS] Update comment & test to explicit state which shared credentials will be used

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -201,10 +201,10 @@ func GetCredentialsFromSession(c *Config) (*awsCredentials.Credentials, error) {
 	return creds, nil
 }
 
-// GetCredentials gets credentials from the environment, shared credentials,
-// the session (which may include a credential process), or ECS/EC2 metadata endpoints.
-// GetCredentials also validates the credentials and the ability to assume a role
-// or will return an error if unsuccessful.
+// GetCredentials gets credentials from environment, shared credentials file,
+// environment AWS_SHARED_CREDENTIALS_FILE, the session (which may include a credential process),
+// or ECS/EC2 metadata endpoints. GetCredentials also validates the credentials
+// and the ability to assume a role or will return an error if unsuccessful.
 func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	sharedCredentialsFilename, err := homedir.Expand(c.CredsFilename)
 

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -691,7 +691,7 @@ func TestAWSGetCredentials_shouldBeShared(t *testing.T) {
 	}
 
 	if v.SecretAccessKey != "secretkey" {
-		t.Fatalf("SecretAccessKey mismatch, expected (%s), got (%s)", "accesskey", v.AccessKeyID)
+		t.Fatalf("SecretAccessKey mismatch, expected (%s), got (%s)", "secretkey", v.SecretAccessKey)
 	}
 }
 


### PR DESCRIPTION
It may be presumed that the environment variable `AWS_SHARED_CREDENTIALS_FILE` will override the `shared_credentials_file`. However, this currently does not happen (as shown in the tests).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Any feedback welcome,
Thanks