### PR TITLE
Optionally log the STS API calls when assuming a role

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -260,6 +260,11 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 		HTTPClient:       cleanhttp.DefaultClient(),
 	}
 
+	if c.DebugLogging {
+		awsConfig.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+		awsConfig.Logger = DebugLogger{}
+	}
+
 	assumeRoleSession, err := session.NewSession(awsConfig)
 
 	if err != nil {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/terraform-providers/terraform-provider-aws/issues/14435.

Adds the ability to log calls to the STS API when assuming a role if the `TF_LOG` environment is set to `DEBUG` or higher.