### PR TITLE
pass custom CredsFilename to Session - solves aws provider #16894 

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -168,26 +168,26 @@ func parseAccountIDAndPartitionFromARN(inputARN string) (string, string, error) 
 // session uses the AWS SDK Go chain of providers so may use a provider (e.g.,
 // ProcessProvider) that is not part of the Terraform provider chain.
 func GetCredentialsFromSession(c *Config, sharedCredentialsFilename string) (*awsCredentials.Credentials, error) {
-        log.Printf("[INFO] Attempting to use session-derived credentials")
+	log.Printf("[INFO] Attempting to use session-derived credentials")
 
-        var sharedConfig []string
+	var sharedConfig []string
 
-        if sharedCredentialsFilename != "" {
-                sharedConfig = []string{sharedCredentialsFilename}
-        }
+	if sharedCredentialsFilename != "" {
+		sharedConfig = []string{sharedCredentialsFilename}
+	}
 
-        // Avoid setting HTTPClient here as it will prevent the ec2metadata
-        // client from automatically lowering the timeout to 1 second.
-        options := &session.Options{
-                Config: aws.Config{
-                        EndpointResolver: c.EndpointResolver(),
-                        MaxRetries:       aws.Int(0),
-                        Region:           aws.String(c.Region),
-                },
-                Profile:           c.Profile,
-                SharedConfigFiles: sharedConfig,
-                SharedConfigState: session.SharedConfigEnable,
-        }
+	// Avoid setting HTTPClient here as it will prevent the ec2metadata
+	// client from automatically lowering the timeout to 1 second.
+	options := &session.Options{
+		Config: aws.Config{
+			EndpointResolver: c.EndpointResolver(),
+			MaxRetries:       aws.Int(0),
+			Region:           aws.String(c.Region),
+		},
+		Profile:           c.Profile,
+		SharedConfigFiles: sharedConfig,
+		SharedConfigState: session.SharedConfigEnable,
+	}
 	sess, err := session.NewSessionWithOptions(*options)
 	if err != nil {
 		if tfawserr.ErrCodeEquals(err, "NoCredentialProviders") {

--- a/awsauth.go
+++ b/awsauth.go
@@ -171,7 +171,7 @@ func GetCredentialsFromSession(c *Config, sharedCredentialsFilename string) (*aw
         log.Printf("[INFO] Attempting to use session-derived credentials")
 
         var sharedConfig []string
-        
+
         if sharedCredentialsFilename != "" {
                 sharedConfig = []string{sharedCredentialsFilename}
         }
@@ -185,7 +185,7 @@ func GetCredentialsFromSession(c *Config, sharedCredentialsFilename string) (*aw
                         Region:           aws.String(c.Region),
                 },
                 Profile:           c.Profile,
-                SharedConfigFiles: sharedConfig, 
+                SharedConfigFiles: sharedConfig,
                 SharedConfigState: session.SharedConfigEnable,
         }
 	sess, err := session.NewSessionWithOptions(*options)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: https://github.com/hashicorp/terraform-provider-aws/issues/16894
(aws provider)
The change passes the custom credential file name to the Session way of resolving credentials - instead of using them only in the custom chain. This allows (see aws provider issue) to use advanced configs beyond simple secret/access keys as well in such custom file locations. If no custom credntial file is passed - nothing changes. 
It should be noted that if the custom credntial file is used , both the respective environment variables and the default location are ignored - which is in line with the documentation. 

Golang is not really my language  ... so sorry if the code is suboptimal. 
