### PR TITLE
Extends ErrCodeEquals() to accept variadic list of AWS error codes to match against

### DIFF
--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -40,6 +40,21 @@ func ErrCodeEquals(err error, code string) bool {
 	return false
 }
 
+// ErrCodeIn returns true if the error matches all these conditions:
+//  * err is of type awserr.Error
+//  * Error.Code() equals one of the passed codes
+func ErrCodeIn(err error, codes ...string) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		for _, code := range codes {
+			if awsErr.Code() == code {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ErrCodeContains returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
 //  * Error.Code() contains code

--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -31,19 +31,8 @@ func ErrMessageAndOrigErrContain(err error, code string, message string, origErr
 
 // ErrCodeEquals returns true if the error matches all these conditions:
 //  * err is of type awserr.Error
-//  * Error.Code() equals code
-func ErrCodeEquals(err error, code string) bool {
-	var awsErr awserr.Error
-	if errors.As(err, &awsErr) {
-		return awsErr.Code() == code
-	}
-	return false
-}
-
-// ErrCodeIn returns true if the error matches all these conditions:
-//  * err is of type awserr.Error
 //  * Error.Code() equals one of the passed codes
-func ErrCodeIn(err error, codes ...string) bool {
+func ErrCodeEquals(err error, codes ...string) bool {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		for _, code := range codes {

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -315,6 +315,97 @@ func TestErrCodeEquals(t *testing.T) {
 	}
 }
 
+func TestErrCodeIn(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Codes    []string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+			Err:  nil,
+		},
+		{
+			Name:  "nil error code",
+			Err:   nil,
+			Codes: []string{"test"},
+		},
+		{
+			Name: "other error",
+			Err:  errors.New("test"),
+		},
+		{
+			Name:  "other error code",
+			Err:   errors.New("test"),
+			Codes: []string{"test"},
+		},
+		{
+			Name:     "awserr error matching first code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Codes:    []string{"TestCode", "NotMatching"},
+			Expected: true,
+		},
+		{
+			Name:     "awserr error matching last code",
+			Err:      awserr.New("TestCode", "TestMessage", nil),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name: "awserr error no code",
+			Err:  awserr.New("TestCode", "TestMessage", nil),
+		},
+		{
+			Name:  "awserr error non-matching codes",
+			Err:   awserr.New("TestCode", "TestMessage", nil),
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+		{
+			Name: "wrapped other error",
+			Err:  fmt.Errorf("test: %w", errors.New("test")),
+		},
+		{
+			Name:  "wrapped other error code",
+			Err:   fmt.Errorf("test: %w", errors.New("test")),
+			Codes: []string{"test"},
+		},
+		{
+			Name:     "wrapped awserr error matching first code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Codes:    []string{"TestCode", "NotMatching"},
+			Expected: true,
+		},
+		{
+			Name:     "wrapped awserr error matching last code",
+			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name: "wrapped awserr error no code",
+			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+		},
+		{
+			Name:  "wrapped awserr error non-matching codes",
+			Err:   fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := ErrCodeIn(testCase.Err, testCase.Codes...)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
 func TestErrCodeContains(t *testing.T) {
 	testCases := []struct {
 		Name     string

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -240,85 +240,6 @@ func TestErrCodeEquals(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Err      error
-		Code     string
-		Expected bool
-	}{
-		{
-			Name: "nil error",
-			Err:  nil,
-		},
-		{
-			Name: "nil error code",
-			Err:  nil,
-			Code: "test",
-		},
-		{
-			Name: "other error",
-			Err:  errors.New("test"),
-		},
-		{
-			Name: "other error code",
-			Err:  errors.New("test"),
-			Code: "test",
-		},
-		{
-			Name:     "awserr error matching code",
-			Err:      awserr.New("TestCode", "TestMessage", nil),
-			Code:     "TestCode",
-			Expected: true,
-		},
-		{
-			Name: "awserr error no code",
-			Err:  awserr.New("TestCode", "TestMessage", nil),
-		},
-		{
-			Name: "awserr error non-matching code",
-			Err:  awserr.New("TestCode", "TestMessage", nil),
-			Code: "NotMatching",
-		},
-		{
-			Name: "wrapped other error",
-			Err:  fmt.Errorf("test: %w", errors.New("test")),
-		},
-		{
-			Name: "wrapped other error code",
-			Err:  fmt.Errorf("test: %w", errors.New("test")),
-			Code: "test",
-		},
-		{
-			Name:     "wrapped awserr error matching code",
-			Err:      fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code:     "TestCode",
-			Expected: true,
-		},
-		{
-			Name: "wrapped awserr error no code",
-			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-		},
-		{
-			Name: "wrapped awserr error non-matching code",
-			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
-			Code: "NotMatching",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.Name, func(t *testing.T) {
-			got := ErrCodeEquals(testCase.Err, testCase.Code)
-
-			if got != testCase.Expected {
-				t.Errorf("got %t, expected %t", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-func TestErrCodeIn(t *testing.T) {
-	testCases := []struct {
-		Name     string
-		Err      error
 		Codes    []string
 		Expected bool
 	}{
@@ -343,7 +264,7 @@ func TestErrCodeIn(t *testing.T) {
 		{
 			Name:     "awserr error matching first code",
 			Err:      awserr.New("TestCode", "TestMessage", nil),
-			Codes:    []string{"TestCode", "NotMatching"},
+			Codes:    []string{"TestCode"},
 			Expected: true,
 		},
 		{
@@ -355,6 +276,11 @@ func TestErrCodeIn(t *testing.T) {
 		{
 			Name: "awserr error no code",
 			Err:  awserr.New("TestCode", "TestMessage", nil),
+		},
+		{
+			Name:  "awserr error non-matching code",
+			Err:   awserr.New("TestCode", "TestMessage", nil),
+			Codes: []string{"NotMatching"},
 		},
 		{
 			Name:  "awserr error non-matching codes",
@@ -387,6 +313,11 @@ func TestErrCodeIn(t *testing.T) {
 			Err:  fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
 		},
 		{
+			Name:  "wrapped awserr error non-matching code",
+			Err:   fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
+			Codes: []string{"NotMatching"},
+		},
+		{
 			Name:  "wrapped awserr error non-matching codes",
 			Err:   fmt.Errorf("test: %w", awserr.New("TestCode", "TestMessage", nil)),
 			Codes: []string{"NotMatching", "AlsoNotMatching"},
@@ -397,7 +328,7 @@ func TestErrCodeIn(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Name, func(t *testing.T) {
-			got := ErrCodeIn(testCase.Err, testCase.Codes...)
+			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)


### PR DESCRIPTION
Extends `ErrCodeEquals()` to compares the code of an `awserr.Error` against a variadic list of codes.

Previously

```go
if tfawserr.ErrCodeEquals(err, tfec2.InvalidSecurityGroupIDNotFound) ||
	tfawserr.ErrCodeEquals(err, tfec2.InvalidGroupNotFound) {
	...
}
```

now

```go
if tfawserr.ErrCodeEquals(err, tfec2.InvalidSecurityGroupIDNotFound, tfec2.InvalidGroupNotFound) {
	...
}
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes: #54
