### PR TITLE
Enable verbose credential obtainment logging on debug

### DIFF
--- a/awsauth.go
+++ b/awsauth.go
@@ -261,6 +261,7 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	}
 
 	if c.DebugLogging {
+		awsConfig.CredentialsChainVerboseErrors = aws.Bool(true)
 		awsConfig.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
 		awsConfig.Logger = DebugLogger{}
 	}

--- a/session.go
+++ b/session.go
@@ -63,6 +63,7 @@ func GetSessionOptions(c *Config) (*session.Options, error) {
 	}
 
 	if c.DebugLogging {
+		options.Config.CredentialsChainVerboseErrors = aws.Bool(true)
 		options.Config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
 		options.Config.Logger = DebugLogger{}
 	}


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Reference: #25 

When DebugLogging is enabled, toggle on the verbose credentials errors.