### PR TITLE
V2: Replace `DurationSeconds` with `Duration`

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -89,9 +89,9 @@ func TestGetAwsConfig(t *testing.T) {
 			Config: &Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				AssumeRole: &AssumeRole{
-					RoleARN:         servicemocks.MockStsAssumeRoleArn,
-					DurationSeconds: 3600,
-					SessionName:     servicemocks.MockStsAssumeRoleSessionName,
+					RoleARN:     servicemocks.MockStsAssumeRoleArn,
+					Duration:    1 * time.Hour,
+					SessionName: servicemocks.MockStsAssumeRoleSessionName,
 				},
 				Region:    "us-east-1",
 				SecretKey: servicemocks.MockStaticSecretKey,

--- a/credentials.go
+++ b/credentials.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -73,7 +72,7 @@ func assumeRoleCredentialsProvider(ctx context.Context, awsConfig aws.Config, c 
 
 	appCreds := stscreds.NewAssumeRoleProvider(client, ar.RoleARN, func(opts *stscreds.AssumeRoleOptions) {
 		opts.RoleSessionName = ar.SessionName
-		opts.Duration = time.Duration(ar.DurationSeconds) * time.Second
+		opts.Duration = ar.Duration
 
 		if ar.ExternalID != "" {
 			opts.ExternalID = aws.String(ar.ExternalID)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 type Config struct {
 	AccessKey              string
 	APNInfo                *APNInfo
@@ -35,7 +37,7 @@ type APNProduct struct {
 
 type AssumeRole struct {
 	RoleARN           string
-	DurationSeconds   int
+	Duration          time.Duration
 	ExternalID        string
 	Policy            string
 	PolicyARNs        []string

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -131,9 +131,9 @@ func TestGetSession(t *testing.T) {
 			Config: &awsbase.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				AssumeRole: &awsbase.AssumeRole{
-					RoleARN:         servicemocks.MockStsAssumeRoleArn,
-					DurationSeconds: 3600,
-					SessionName:     servicemocks.MockStsAssumeRoleSessionName,
+					RoleARN:     servicemocks.MockStsAssumeRoleArn,
+					Duration:    1 * time.Hour,
+					SessionName: servicemocks.MockStsAssumeRoleSessionName,
 				},
 				Region:    "us-east-1",
 				SecretKey: servicemocks.MockStaticSecretKey,


### PR DESCRIPTION
Replaces the `AssumeRole` field `DurationSeconds` with `Duration` with type `time.Duration`. This matches the AWS SDK for Go v2 (and v1)