### PR TITLE
Exposes AWS SDK v1 session user agent handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,8 @@ type APNInfo = config.APNInfo
 
 type AssumeRole = config.AssumeRole
 
+type UserAgentProducts = config.UserAgentProducts
+
 type UserAgentProduct = config.UserAgentProduct
 
 const (


### PR DESCRIPTION
Exposes user agent handling for AWS SDK for Go v1 `session.Session`s. Used by `NewSessionForRegion` (https://github.com/hashicorp/terraform-provider-aws/blob/038c3b4c3b9b1ee7d2162985e80a01475b029e0b/internal/conns/conns.go#L1834) in the AWS provider