### PR TITLE
Remove `DebugLogging` parameter from `awsbase.Config` and always enable logging

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -159,19 +159,14 @@ func commonLoadOptions(c *Config) ([]func(*config.LoadOptions) error, error) {
 		config.WithRegion(c.Region),
 		config.WithHTTPClient(httpClient),
 		config.WithAPIOptions(apiOptions),
+		config.WithClientLogMode(aws.LogRequestWithBody | aws.LogResponseWithBody | aws.LogRetries),
+		config.WithLogger(debugLogger{}),
 	}
 
 	if len(c.SharedConfigFiles) > 0 {
 		loadOptions = append(
 			loadOptions,
 			config.WithSharedConfigFiles(c.SharedConfigFiles),
-		)
-	}
-
-	if c.DebugLogging {
-		loadOptions = append(loadOptions,
-			config.WithClientLogMode(aws.LogRequestWithBody|aws.LogResponseWithBody|aws.LogRetries),
-			config.WithLogger(debugLogger{}),
 		)
 	}
 

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -757,9 +757,8 @@ region = us-east-1
 					RoleARN:     servicemocks.MockStsAssumeRoleArn,
 					SessionName: servicemocks.MockStsAssumeRoleSessionName,
 				},
-				DebugLogging: true,
-				Region:       "us-east-1",
-				SecretKey:    servicemocks.MockStaticSecretKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
 			},
 			Description: "assume role error",
 			ExpectedError: func(err error) bool {
@@ -2004,7 +2003,6 @@ func TestRetryHandlers(t *testing.T) {
 				MaxRetries:          maxRetries,
 				SecretKey:           servicemocks.MockStaticSecretKey,
 				SkipCredsValidation: true,
-				DebugLogging:        true,
 			}
 			awsConfig, err := GetAwsConfig(context.Background(), config)
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ type Config struct {
 	AssumeRole                     *AssumeRole
 	CallerDocumentationURL         string
 	CallerName                     string
-	DebugLogging                   bool
 	EC2MetadataServiceEndpoint     string
 	EC2MetadataServiceEndpointMode string
 	HTTPProxy                      string

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -54,17 +54,13 @@ func getSessionOptions(awsC *awsv2.Config, c *awsbase.Config) (*session.Options,
 				creds.SessionToken,
 			),
 			HTTPClient:           httpClient,
+			LogLevel:             aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors),
+			Logger:               debugLogger{},
 			MaxRetries:           aws.Int(0),
 			Region:               aws.String(awsC.Region),
 			UseFIPSEndpoint:      convertFIPSEndpointState(useFIPSEndpoint),
 			UseDualStackEndpoint: convertDualStackEndpointState(useDualStackEndpoint),
 		},
-	}
-
-	// This needs its own debug logger. Don't reuse or wrap the AWS SDK for Go v2 logger, since it hardcodes the string "aws-sdk-go-v2"
-	if c.DebugLogging {
-		options.Config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
-		options.Config.Logger = debugLogger{}
 	}
 
 	return options, nil

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -41,7 +41,7 @@ func TestGetSessionOptions(t *testing.T) {
 			false,
 		},
 		{"ConfigWithCredsAndOptions",
-			&awsbase.Config{AccessKey: "MockAccessKey", SecretKey: "MockSecretKey", Insecure: true, DebugLogging: true},
+			&awsbase.Config{AccessKey: "MockAccessKey", SecretKey: "MockSecretKey", Insecure: true},
 			false,
 		},
 	}
@@ -799,9 +799,8 @@ region = us-east-1
 					RoleARN:     servicemocks.MockStsAssumeRoleArn,
 					SessionName: servicemocks.MockStsAssumeRoleSessionName,
 				},
-				DebugLogging: true,
-				Region:       "us-east-1",
-				SecretKey:    servicemocks.MockStaticSecretKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
 			},
 			Description: "assume role error",
 			ExpectedError: func(err error) bool {


### PR DESCRIPTION
Terraform handles log levels, so request/response logging should always be enabled

Closes #96