### PR TITLE
Use `AWS_MAX_ATTEMPTS` environment variable to configure AWS SDK max attempts

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,6 +42,11 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 
 	var retryer aws.Retryer
 	retryer = retry.NewStandard()
+	if maxAttempts := os.Getenv("AWS_MAX_ATTEMPTS"); maxAttempts != "" {
+		if i, err := strconv.Atoi(maxAttempts); err == nil {
+			retryer = retry.AddWithMaxAttempts(retryer, i)
+		}
+	}
 	if c.MaxRetries != 0 {
 		retryer = retry.AddWithMaxAttempts(retryer, c.MaxRetries)
 	}

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -81,8 +81,9 @@ func GetSession(awsC *awsv2.Config, c *awsbase.Config) (*session.Session, error)
 		return nil, fmt.Errorf("Error creating AWS session: %w", err)
 	}
 
-	if c.MaxRetries > 0 {
-		sess = sess.Copy(&aws.Config{MaxRetries: aws.Int(c.MaxRetries)})
+	// Set retries after resolving credentials to prevent retries during resolution
+	if retryer := awsC.Retryer(); retryer != nil {
+		sess = sess.Copy(&aws.Config{MaxRetries: aws.Int(retryer.MaxAttempts())})
 	}
 
 	SetSessionUserAgent(sess, c.APNInfo, c.UserAgent)


### PR DESCRIPTION
Use `AWS_MAX_ATTEMPTS` environment variable to configure AWS SDK max attempts

Closes #101 