### PR TITLE
Add missing AWS Regions for validation

### DIFF
--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -49,6 +49,7 @@ func (p partition) Partition() Partition {
 }
 
 // TODO: this should be generated from the AWS SDK source data
+// Data from https://github.com/aws/aws-sdk-go/blob/main/models/endpoints/endpoints.json.
 var partitions = []partition{
 	{
 		id:          "aws",
@@ -58,9 +59,11 @@ var partitions = []partition{
 			"ap-east-1",      // Asia Pacific (Hong Kong).
 			"ap-northeast-1", // Asia Pacific (Tokyo).
 			"ap-northeast-2", // Asia Pacific (Seoul).
+			"ap-northeast-3", // Asia Pacific (Osaka).
 			"ap-south-1",     // Asia Pacific (Mumbai).
 			"ap-southeast-1", // Asia Pacific (Singapore).
 			"ap-southeast-2", // Asia Pacific (Sydney).
+			"ap-southeast-3", // Asia Pacific (Jakarta).
 			"ca-central-1",   // Canada (Central).
 			"eu-central-1",   // Europe (Frankfurt).
 			"eu-north-1",     // Europe (Stockholm).
@@ -97,13 +100,14 @@ var partitions = []partition{
 		regionRegex: regexp.MustCompile(`^us\-iso\-\w+\-\d+$`),
 		regions: []string{
 			"us-iso-east-1", // US ISO East.
+			"us-iso-west-1", // US ISO WEST.
 		},
 	},
 	{
 		id:          "aws-iso-b",
 		regionRegex: regexp.MustCompile(`^us\-isob\-\w+\-\d+$`),
 		regions: []string{
-			"us-isob-east-1", // US ISO East.
+			"us-isob-east-1", // US ISOB East (Ohio).
 		},
 	},
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -14,6 +14,10 @@ func TestValidateRegion(t *testing.T) {
 			ExpectError: false,
 		},
 		{
+			Region:      "ap-northeast-3",
+			ExpectError: false,
+		},
+		{
 			Region:      "us-gov-west-1",
 			ExpectError: false,
 		},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/23116.
Adds missing `ap-northeast-3` and `ap-southeast-3` AWS Regions (plus others) for validation.

```console
% go test -v '-run=TestValidateRegion' .
=== RUN   TestValidateRegion
=== RUN   TestValidateRegion/us-east-1
=== RUN   TestValidateRegion/ap-northeast-3
=== RUN   TestValidateRegion/us-gov-west-1
=== RUN   TestValidateRegion/cn-northwest-1
=== RUN   TestValidateRegion/invalid
--- PASS: TestValidateRegion (0.00s)
    --- PASS: TestValidateRegion/us-east-1 (0.00s)
    --- PASS: TestValidateRegion/ap-northeast-3 (0.00s)
    --- PASS: TestValidateRegion/us-gov-west-1 (0.00s)
    --- PASS: TestValidateRegion/cn-northwest-1 (0.00s)
    --- PASS: TestValidateRegion/invalid (0.00s)
PASS
ok  	github.com/hashicorp/aws-sdk-go-base/v2	0.242s
```

Previously

```
=== RUN   TestValidateRegion/ap-northeast-3
    validation_test.go:40: Expected no error, received error: Invalid AWS Region: ap-northeast-3
```