### PR TITLE
Pre-validates Profile names before using it for authentication

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -813,6 +813,40 @@ source_profile = SourceSharedCredentials
 			},
 			ExpectedRegion: "us-east-1",
 		},
+		{
+			Config: &Config{
+				Region: "us-east-1",
+			},
+			Description: "invalid profile name from envvar",
+			EnvironmentVariables: map[string]string{
+				"AWS_PROFILE": "no-such-profile",
+			},
+			ExpectedError: func(err error) bool {
+				var e config.SharedConfigProfileNotExistError
+				return errors.As(err, &e)
+			},
+			SharedCredentialsFile: `
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
+		},
+		{
+			Config: &Config{
+				Profile: "no-such-profile",
+				Region:  "us-east-1",
+			},
+			Description: "invalid profile name from config",
+			ExpectedError: func(err error) bool {
+				var e config.SharedConfigProfileNotExistError
+				return errors.As(err, &e)
+			},
+			SharedCredentialsFile: `
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,3 +63,19 @@ func (c Config) CustomCABundleReader() (*bytes.Reader, error) {
 	}
 	return bytes.NewReader(bundle), nil
 }
+
+func (c Config) ResolveSharedConfigFiles() ([]string, error) {
+	v, err := expand.FilePaths(c.SharedConfigFiles)
+	if err != nil {
+		return []string{}, fmt.Errorf("expanding shared config files: %w", err)
+	}
+	return v, nil
+}
+
+func (c Config) ResolveSharedCredentialsFiles() ([]string, error) {
+	v, err := expand.FilePaths(c.SharedCredentialsFiles)
+	if err != nil {
+		return []string{}, fmt.Errorf("expanding shared credentials files: %w", err)
+	}
+	return v, nil
+}

--- a/v2/awsv1shim/go.mod
+++ b/v2/awsv1shim/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2
 require (
 	github.com/aws/aws-sdk-go v1.42.52
 	github.com/aws/aws-sdk-go-v2 v1.13.0
+	github.com/aws/aws-sdk-go-v2/config v1.13.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.8.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.14.0
 	github.com/google/go-cmp v0.5.7


### PR DESCRIPTION
The default AWS SDK authentication flow silently ignores missing profiles, so pre-validate it

Closes #127
Reference hashicorp/terraform-provider-aws#23261
Reference aws/aws-sdk-go-v2#1591

Please briefly describe the changes proposed in this pull request.
