### PR TITLE
Adds logging for authentication flow

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -35,10 +35,12 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 		}
 	}
 
-	credentialsProvider, source, err := getCredentialsProvider(ctx, c)
+	credentialsProvider, initialSource, err := getCredentialsProvider(ctx, c)
 	if err != nil {
 		return aws.Config{}, err
 	}
+	creds, _ := credentialsProvider.Retrieve(ctx)
+	log.Printf("[INFO] Retrieved credentials from %q", creds.Source)
 
 	var retryer aws.Retryer
 	retryer = retry.NewStandard()
@@ -65,7 +67,7 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 			return retryer
 		}),
 	)
-	if source == ec2rolecreds.ProviderName {
+	if initialSource == ec2rolecreds.ProviderName {
 		loadOptions = append(
 			loadOptions,
 			config.WithEC2IMDSRegion(),

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -847,6 +847,48 @@ aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
 `,
 		},
+		{
+			Config:      &Config{},
+			Description: "AWS_ACCESS_KEY_ID overrides AWS_PROFILE",
+			EnvironmentVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
+				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
+				"AWS_PROFILE":           "SharedCredentialsProfile",
+			},
+			SharedCredentialsFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+
+[SharedCredentialsProfile]
+aws_access_key_id = ProfileSharedCredentialsAccessKey
+aws_secret_access_key = ProfileSharedCredentialsSecretKey
+`,
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+			},
+			ExpectedCredentialsValue: mockdata.MockEnvCredentials,
+		},
+		{
+			Config: &Config{
+				Region: "us-east-1",
+			},
+			Description: "AWS_ACCESS_KEY_ID does not override invalid profile name from envvar",
+			EnvironmentVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
+				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
+				"AWS_PROFILE":           "no-such-profile",
+			},
+			ExpectedError: func(err error) bool {
+				var e config.SharedConfigProfileNotExistError
+				return errors.As(err, &e)
+			},
+			SharedCredentialsFile: `
+[some-profile]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/credentials.go
+++ b/credentials.go
@@ -38,26 +38,26 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 		profile = envConfig.SharedConfigProfile
 	}
 
-	sharedCredentialsFiles, err := c.ResolveSharedCredentialsFiles()
-	if err != nil {
-		return nil, "", err
-	}
-	if len(sharedCredentialsFiles) == 0 {
-		sharedCredentialsFiles = []string{envConfig.SharedCredentialsFile}
-	}
-
-	sharedConfigFiles, err := c.ResolveSharedConfigFiles()
-	if err != nil {
-		return nil, "", err
-	}
-	if len(sharedConfigFiles) == 0 {
-		sharedConfigFiles = []string{envConfig.SharedConfigFile}
-	}
-
 	// The default AWS SDK authentication flow silently ignores invalid Profiles. Pre-validate that the Profile exists
 	// https://github.com/aws/aws-sdk-go-v2/issues/1591
 	if profile != "" {
-		_, err := config.LoadSharedConfigProfile(ctx, profile, func(opts *config.LoadSharedConfigOptions) {
+		sharedCredentialsFiles, err := c.ResolveSharedCredentialsFiles()
+		if err != nil {
+			return nil, "", err
+		}
+		if len(sharedCredentialsFiles) == 0 {
+			sharedCredentialsFiles = []string{envConfig.SharedCredentialsFile}
+		}
+
+		sharedConfigFiles, err := c.ResolveSharedConfigFiles()
+		if err != nil {
+			return nil, "", err
+		}
+		if len(sharedConfigFiles) == 0 {
+			sharedConfigFiles = []string{envConfig.SharedConfigFile}
+		}
+
+		_, err = config.LoadSharedConfigProfile(ctx, profile, func(opts *config.LoadSharedConfigOptions) {
 			opts.CredentialsFiles = sharedCredentialsFiles
 			opts.ConfigFiles = sharedConfigFiles
 		})
@@ -68,7 +68,6 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 			loadOptions,
 			config.WithSharedConfigProfile(c.Profile),
 		)
-
 	}
 
 	if c.AccessKey != "" || c.SecretKey != "" || c.Token != "" {

--- a/credentials.go
+++ b/credentials.go
@@ -64,6 +64,10 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 		if err != nil {
 			return nil, "", err
 		}
+	}
+	// We need to validate both the configured and envvar named profiles for validity,
+	// but to use proper precedence, we only set the configured named profile
+	if c.Profile != "" {
 		loadOptions = append(
 			loadOptions,
 			config.WithSharedConfigProfile(c.Profile),


### PR DESCRIPTION
Adds logging for authentication flow. Also adds warning and additional error info when `Profile` and `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars are set.

Closes #134
Closes #135 