### PR TITLE
Don't override shared files unless they're set

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -83,8 +83,12 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 		}
 
 		_, err = config.LoadSharedConfigProfile(ctx, profile, func(opts *config.LoadSharedConfigOptions) {
-			opts.CredentialsFiles = sharedCredentialsFiles
-			opts.ConfigFiles = sharedConfigFiles
+			if len(sharedCredentialsFiles) != 0 {
+				opts.CredentialsFiles = sharedCredentialsFiles
+			}
+			if len(sharedConfigFiles) != 0 {
+				opts.ConfigFiles = sharedConfigFiles
+			}
 		})
 		if err != nil {
 			return nil, "", err


### PR DESCRIPTION
In profile validation, only override shared config and credentials files if they're set