### PR TITLE
Filters out CR (`\r`) characters from log messages

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package awsbase
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/smithy-go/logging"
 )
@@ -10,5 +11,7 @@ import (
 type debugLogger struct{}
 
 func (l debugLogger) Logf(classification logging.Classification, format string, v ...interface{}) {
-	log.Printf("[%s] [aws-sdk-go-v2] %s", classification, fmt.Sprintf(format, v...))
+	s := fmt.Sprintf(format, v...)
+	s = strings.ReplaceAll(s, "\r", "") // Works around https://github.com/jen20/teamcity-go-test/pull/2
+	log.Printf("[%s] [aws-sdk-go-v2] %s", classification, s)
 }


### PR DESCRIPTION
HTTP request and response messages from the AWS SDK for Go v2 include the CR from the CRLF line endings for HTTP message headers. [`teamcity-go-test`](https://github.com/jen20/teamcity-go-test) does not escape the CR characters, causing TeamCity logging to break.

Reference jen20/teamcity-go-test#2
Reference https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values