### PR TITLE
Filters out CR (`\r`) characters from log messages in `awsv1shim`

### DIFF
--- a/v2/awsv1shim/logger.go
+++ b/v2/awsv1shim/logger.go
@@ -14,5 +14,7 @@ func (l debugLogger) Log(args ...interface{}) {
 			tokens = append(tokens, token)
 		}
 	}
-	log.Printf("[DEBUG] [aws-sdk-go] %s", strings.Join(tokens, " "))
+	s := strings.Join(tokens, " ")
+	s = strings.ReplaceAll(s, "\r", "") // Works around https://github.com/jen20/teamcity-go-test/pull/2
+	log.Printf("[DEBUG] [aws-sdk-go] %s", s)
 }


### PR DESCRIPTION
HTTP request and response messages from the AWS API include the CR from the CRLF line endings for HTTP message headers. This appears to be a recent change. [`teamcity-go-test`](https://github.com/jen20/teamcity-go-test) does not escape the CR characters, causing TeamCity logging to break.

Reference https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values