### PR TITLE
Implements tests for custom CA bundle support in shared configuration files

### DIFF
--- a/.semgrep/imports.yml
+++ b/.semgrep/imports.yml
@@ -30,4 +30,6 @@ rules:
           regex: '^"github.com/aws/aws-sdk-go-v2/.+"$'
       - pattern-not: |
           import ("github.com/aws/aws-sdk-go-v2/aws/transport/http")
+      - pattern-not: |
+          import ("github.com/aws/aws-sdk-go-v2/config")
     severity: ERROR

--- a/v2/awsv1shim/resolvers.go
+++ b/v2/awsv1shim/resolvers.go
@@ -1,6 +1,6 @@
 package awsv1shim
 
-import (
+import ( // nosemgrep: no-sdkv2-imports-in-awsv1shim
 	"bytes"
 	"context"
 	"io"

--- a/v2/awsv1shim/resolvers.go
+++ b/v2/awsv1shim/resolvers.go
@@ -1,23 +1,23 @@
 package awsv1shim
 
-import ( // nosemgrep: no-sdkv2-imports-in-awsv1shim
+import (
 	"bytes"
 	"context"
 	"io"
 	"io/ioutil"
 	"log"
 
-	"github.com/aws/aws-sdk-go-v2/config"
+	configv2 "github.com/aws/aws-sdk-go-v2/config"
 )
 
 func resolveCustomCABundle(ctx context.Context, configSources []interface{}) (value io.Reader, found bool, err error) {
 	for _, source := range configSources {
 		switch cfg := source.(type) {
-		case config.LoadOptions:
+		case configv2.LoadOptions:
 			value, found, err = loadOptionsGetCustomCABundle(ctx, cfg)
-		case config.EnvConfig:
+		case configv2.EnvConfig:
 			value, found, err = envConfigGetCustomCABundle(ctx, cfg)
-		case config.SharedConfig:
+		case configv2.SharedConfig:
 			value, found, err = sharedConfigGetCustomCABundle(ctx, cfg)
 		default:
 			log.Printf("[WARN] Unrecognized config source: %T", source)
@@ -32,7 +32,7 @@ func resolveCustomCABundle(ctx context.Context, configSources []interface{}) (va
 }
 
 // Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/load_options.go#L334-L340
-func loadOptionsGetCustomCABundle(_ context.Context, o config.LoadOptions) (io.Reader, bool, error) { //nolint:unparam
+func loadOptionsGetCustomCABundle(_ context.Context, o configv2.LoadOptions) (io.Reader, bool, error) { //nolint:unparam
 	if o.CustomCABundle == nil {
 		return nil, false, nil
 	}
@@ -41,7 +41,7 @@ func loadOptionsGetCustomCABundle(_ context.Context, o config.LoadOptions) (io.R
 }
 
 // Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/env_config.go#L463-L473
-func envConfigGetCustomCABundle(_ context.Context, c config.EnvConfig) (io.Reader, bool, error) {
+func envConfigGetCustomCABundle(_ context.Context, c configv2.EnvConfig) (io.Reader, bool, error) {
 	if len(c.CustomCABundle) == 0 {
 		return nil, false, nil
 	}
@@ -54,7 +54,7 @@ func envConfigGetCustomCABundle(_ context.Context, c config.EnvConfig) (io.Reade
 }
 
 // Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/shared_config.go#L350-L360
-func sharedConfigGetCustomCABundle(_ context.Context, c config.SharedConfig) (io.Reader, bool, error) {
+func sharedConfigGetCustomCABundle(_ context.Context, c configv2.SharedConfig) (io.Reader, bool, error) {
 	if len(c.CustomCABundle) == 0 {
 		return nil, false, nil
 	}

--- a/v2/awsv1shim/resolvers.go
+++ b/v2/awsv1shim/resolvers.go
@@ -1,0 +1,67 @@
+package awsv1shim
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+func resolveCustomCABundle(ctx context.Context, configSources []interface{}) (value io.Reader, found bool, err error) {
+	for _, source := range configSources {
+		switch cfg := source.(type) {
+		case config.LoadOptions:
+			value, found, err = loadOptionsGetCustomCABundle(ctx, cfg)
+		case config.EnvConfig:
+			value, found, err = envConfigGetCustomCABundle(ctx, cfg)
+		case config.SharedConfig:
+			value, found, err = sharedConfigGetCustomCABundle(ctx, cfg)
+		default:
+			log.Printf("[WARN] Unrecognized config source: %T", source)
+			continue
+		}
+		if err != nil || found {
+			break
+		}
+	}
+
+	return
+}
+
+// Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/load_options.go#L334-L340
+func loadOptionsGetCustomCABundle(_ context.Context, o config.LoadOptions) (io.Reader, bool, error) { //nolint:unparam
+	if o.CustomCABundle == nil {
+		return nil, false, nil
+	}
+
+	return o.CustomCABundle, true, nil
+}
+
+// Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/env_config.go#L463-L473
+func envConfigGetCustomCABundle(_ context.Context, c config.EnvConfig) (io.Reader, bool, error) {
+	if len(c.CustomCABundle) == 0 {
+		return nil, false, nil
+	}
+
+	b, err := ioutil.ReadFile(c.CustomCABundle)
+	if err != nil {
+		return nil, false, err
+	}
+	return bytes.NewReader(b), true, nil
+}
+
+// Copied from https://github.com/aws/aws-sdk-go-v2/blob/889e1da2776ae5bd6d056cf44f6ce6d043237769/config/shared_config.go#L350-L360
+func sharedConfigGetCustomCABundle(_ context.Context, c config.SharedConfig) (io.Reader, bool, error) {
+	if len(c.CustomCABundle) == 0 {
+		return nil, false, nil
+	}
+
+	b, err := ioutil.ReadFile(c.CustomCABundle)
+	if err != nil {
+		return nil, false, err
+	}
+	return bytes.NewReader(b), true, nil
+}

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -23,12 +23,12 @@ import ( // nosemgrep: no-sdkv2-imports-in-awsv1shim
 func getSessionOptions(awsC *awsv2.Config, c *awsbase.Config) (*session.Options, error) {
 	useFIPSEndpoint, _, err := awsconfig.ResolveUseFIPSEndpoint(context.Background(), awsC.ConfigSources)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving configuration: %w", err)
+		return nil, fmt.Errorf("error resolving FIPS endpoint configuration: %w", err)
 	}
 
 	useDualStackEndpoint, _, err := awsconfig.ResolveUseDualStackEndpoint(context.Background(), awsC.ConfigSources)
 	if err != nil {
-		return nil, fmt.Errorf("error resolving configuration: %w", err)
+		return nil, fmt.Errorf("error resolving dual-stack endpoint configuration: %w", err)
 	}
 
 	httpClient, err := defaultHttpClient(c)
@@ -49,11 +49,17 @@ func getSessionOptions(awsC *awsv2.Config, c *awsbase.Config) (*session.Options,
 		},
 	}
 
+	// We can't reuse the io.Reader from the awsv2.Config, because it's already been read.
+	// Re-create it here from the filename.
 	if c.CustomCABundle != "" {
 		reader, err := c.CustomCABundleReader()
 		if err != nil {
 			return nil, err
 		}
+		options.CustomCABundle = reader
+	} else if reader, found, err := resolveCustomCABundle(context.Background(), awsC.ConfigSources); err != nil {
+		return nil, fmt.Errorf("error resolving custom CA bundle configuration: %w", err)
+	} else if found {
 		options.CustomCABundle = reader
 	}
 


### PR DESCRIPTION
The AWS SDK for Go v2 has added support for custom CA bundles in the shared configuration files.

Closes #148