### PR TITLE
Removes boolean `SkipEC2MetadataApiCheck` in favour of new tri-state `EC2MetadataServiceEnableState`

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -173,6 +173,7 @@ func commonLoadOptions(c *Config) ([]func(*config.LoadOptions) error, error) {
 		config.WithRegion(c.Region),
 		config.WithHTTPClient(httpClient),
 		config.WithAPIOptions(apiOptions),
+		config.WithEC2IMDSClientEnableState(c.EC2MetadataServiceEnableState),
 	}
 
 	if !c.SuppressDebugLog {
@@ -232,12 +233,10 @@ func commonLoadOptions(c *Config) ([]func(*config.LoadOptions) error, error) {
 		)
 	}
 
-	if c.SkipEC2MetadataApiCheck {
-		loadOptions = append(loadOptions,
-			config.WithEC2IMDSClientEnableState(imds.ClientDisabled),
-		)
-
-		// This should not be needed, but https://github.com/aws/aws-sdk-go-v2/issues/1398
+	// This should not be needed, but https://github.com/aws/aws-sdk-go-v2/issues/1398
+	if c.EC2MetadataServiceEnableState == imds.ClientEnabled {
+		os.Setenv("AWS_EC2_METADATA_DISABLED", "false")
+	} else if c.EC2MetadataServiceEnableState == imds.ClientDisabled {
 		os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	}
 

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -804,14 +804,19 @@ source_profile = SourceSharedCredentials
 		},
 		{
 			Config: &Config{
-				Region:                  "us-east-1",
-				SkipEC2MetadataApiCheck: true,
+				Region:                        "us-east-1",
+				EC2MetadataServiceEnableState: imds.ClientDisabled,
 			},
 			Description: "skip EC2 Metadata API check",
 			ExpectedError: func(err error) bool {
 				return IsNoValidCredentialSourcesError(err)
 			},
 			ExpectedRegion: "us-east-1",
+			// The IMDS server must be enabled so that auth will succeed if the IMDS is called
+			EnableEc2MetadataServer: true,
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+			},
 		},
 		{
 			Config: &Config{
@@ -1798,6 +1803,130 @@ use_fips_endpoint = true
 			}
 			if a, e := useDualStackState, testCase.ExpectedUseDualStackEndpointState; a != e {
 				t.Errorf("expected UseDualStackEndpoint %q, got: %q", awsconfig.DualStackEndpointStateString(e), awsconfig.DualStackEndpointStateString(a))
+			}
+		})
+	}
+}
+
+func TestEC2MetadataServiceClientEnableState(t *testing.T) {
+	testCases := map[string]struct {
+		Config                                      *Config
+		EnvironmentVariables                        map[string]string
+		SharedConfigurationFile                     string
+		ExpectedEC2MetadataServiceClientEnableState imds.ClientEnableState
+	}{
+		"no configuration": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientDefaultEnableState,
+		},
+
+		"config enabled": {
+			Config: &Config{
+				AccessKey:                     servicemocks.MockStaticAccessKey,
+				SecretKey:                     servicemocks.MockStaticSecretKey,
+				EC2MetadataServiceEnableState: imds.ClientEnabled,
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientEnabled,
+		},
+		"config disabled": {
+			Config: &Config{
+				AccessKey:                     servicemocks.MockStaticAccessKey,
+				SecretKey:                     servicemocks.MockStaticSecretKey,
+				EC2MetadataServiceEnableState: imds.ClientDisabled,
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientDisabled,
+		},
+
+		"envvar true": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_EC2_METADATA_DISABLED": "true",
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientDisabled,
+		},
+		"envvar false": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_EC2_METADATA_DISABLED": "false",
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientEnabled,
+		},
+
+		"config enabled envvar true": {
+			Config: &Config{
+				AccessKey:                     servicemocks.MockStaticAccessKey,
+				SecretKey:                     servicemocks.MockStaticSecretKey,
+				EC2MetadataServiceEnableState: imds.ClientEnabled,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_EC2_METADATA_DISABLED": "true",
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientEnabled,
+		},
+		"config disabled envvar false": {
+			Config: &Config{
+				AccessKey:                     servicemocks.MockStaticAccessKey,
+				SecretKey:                     servicemocks.MockStaticSecretKey,
+				EC2MetadataServiceEnableState: imds.ClientDisabled,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_EC2_METADATA_DISABLED": "false",
+			},
+			ExpectedEC2MetadataServiceClientEnableState: imds.ClientDisabled,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testName, func(t *testing.T) {
+			oldEnv := servicemocks.InitSessionTestEnv()
+			defer servicemocks.PopEnv(oldEnv)
+
+			for k, v := range testCase.EnvironmentVariables {
+				os.Setenv(k, v)
+			}
+
+			if testCase.SharedConfigurationFile != "" {
+				file, err := ioutil.TempFile("", "aws-sdk-go-base-shared-configuration-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = ioutil.WriteFile(file.Name(), []byte(testCase.SharedConfigurationFile), 0600)
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				testCase.Config.SharedConfigFiles = []string{file.Name()}
+			}
+
+			testCase.Config.SkipCredsValidation = true
+
+			awsConfig, err := GetAwsConfig(context.Background(), testCase.Config)
+			if err != nil {
+				t.Fatalf("error in GetAwsConfig() '%[1]T': %[1]s", err)
+			}
+
+			ec2MetadataServiceClientEnableState, _, err := awsconfig.ResolveEC2IMDSClientEnableState(awsConfig.ConfigSources)
+			if err != nil {
+				t.Fatalf("error in ResolveEC2IMDSClientEnableState: %s", err)
+			}
+			if a, e := ec2MetadataServiceClientEnableState, testCase.ExpectedEC2MetadataServiceClientEnableState; a != e {
+				t.Errorf("expected EC2MetadataServiceClientEnableState %q, got: %q", awsconfig.EC2IMDSClientEnableStateString(e), awsconfig.EC2IMDSClientEnableStateString(a))
 			}
 		})
 	}

--- a/internal/awsconfig/resolvers.go
+++ b/internal/awsconfig/resolvers.go
@@ -69,6 +69,36 @@ func DualStackEndpointStateString(state aws.DualStackEndpointState) string {
 }
 
 // Copied and renamed from https://github.com/aws/aws-sdk-go-v2/blob/main/feature/ec2/imds/internal/config/resolvers.go
+type EC2IMDSClientEnableStateResolver interface {
+	GetEC2IMDSClientEnableState() (imds.ClientEnableState, bool, error)
+}
+
+// Copied and renamed from https://github.com/aws/aws-sdk-go-v2/blob/main/feature/ec2/imds/internal/config/resolvers.go
+func ResolveEC2IMDSClientEnableState(sources []interface{}) (value imds.ClientEnableState, found bool, err error) {
+	for _, source := range sources {
+		if resolver, ok := source.(EC2IMDSClientEnableStateResolver); ok {
+			value, found, err = resolver.GetEC2IMDSClientEnableState()
+			if err != nil || found {
+				return value, found, err
+			}
+		}
+	}
+	return value, found, err
+}
+
+func EC2IMDSClientEnableStateString(state imds.ClientEnableState) string {
+	switch state {
+	case imds.ClientDefaultEnableState:
+		return "ClientDefaultEnableState"
+	case imds.ClientDisabled:
+		return "ClientDisabled"
+	case imds.ClientEnabled:
+		return "ClientEnabled"
+	}
+	return fmt.Sprintf("unknown imds.ClientEnableState (%d)", state)
+}
+
+// Copied and renamed from https://github.com/aws/aws-sdk-go-v2/blob/main/feature/ec2/imds/internal/config/resolvers.go
 type EC2IMDSEndpointResolver interface {
 	GetEC2IMDSEndpoint() (value string, found bool, err error)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/expand"
 )
 
@@ -16,6 +17,7 @@ type Config struct {
 	CallerDocumentationURL         string
 	CallerName                     string
 	CustomCABundle                 string
+	EC2MetadataServiceEnableState  imds.ClientEnableState
 	EC2MetadataServiceEndpoint     string
 	EC2MetadataServiceEndpointMode string
 	HTTPProxy                      string
@@ -28,7 +30,6 @@ type Config struct {
 	SharedCredentialsFiles         []string
 	SharedConfigFiles              []string
 	SkipCredsValidation            bool
-	SkipEC2MetadataApiCheck        bool
 	SkipRequestingAccountId        bool
 	StsEndpoint                    string
 	StsRegion                      string

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -15,6 +15,7 @@ import (
 
 	retryv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
 	configv2 "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -849,14 +850,19 @@ region = us-east-1
 		},
 		{
 			Config: &awsbase.Config{
-				Region:                  "us-east-1",
-				SkipEC2MetadataApiCheck: true,
+				Region:                        "us-east-1",
+				EC2MetadataServiceEnableState: imds.ClientDisabled,
 			},
-			Description: "skip EC2 metadata API check",
+			Description: "skip EC2 Metadata API check",
 			ExpectedError: func(err error) bool {
 				return awsbase.IsNoValidCredentialSourcesError(err)
 			},
 			ExpectedRegion: "us-east-1",
+			// The IMDS server must be enabled so that auth will succeed if the IMDS is called
+			EnableEc2MetadataServer: true,
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+			},
 		},
 		{
 			Config: &awsbase.Config{


### PR DESCRIPTION
To allow overriding the environment variable `AWS_EC2_METADATA_DISABLED` with configuration, use a tri-state value for the IMDS client state. Removes boolean `SkipEC2MetadataApiCheck` and replaces is with `EC2MetadataServiceEnableState` of type `imds.ClientEnableState`.