### PR TITLE
Support sourcing `max_attempts` from shared config file

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -86,14 +86,14 @@ func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
 
 	awsConfig.Retryer = func() aws.Retryer {
 		return &networkErrorShortcutter{
-			Retryer: retry.NewStandard(standardOptions...),
+			RetryerV2: retry.NewStandard(standardOptions...),
 		}
 	}
 }
 
 // networkErrorShortcutter is used to enable networking error shortcutting
 type networkErrorShortcutter struct {
-	aws.Retryer
+	aws.RetryerV2
 }
 
 // We're misusing RetryDelay here, since this is the only function that takes the attempt count
@@ -112,7 +112,7 @@ func (r *networkErrorShortcutter) RetryDelay(attempt int, err error) (time.Durat
 		}
 	}
 
-	return r.Retryer.RetryDelay(attempt, err)
+	return r.RetryerV2.RetryDelay(attempt, err)
 }
 
 func GetAwsAccountIDAndPartition(ctx context.Context, awsConfig aws.Config, c *Config) (string, string, error) {

--- a/aws_config.go
+++ b/aws_config.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/smithy-go/middleware"
+	"github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/constants"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints"
 )
@@ -42,20 +42,6 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 	creds, _ := credentialsProvider.Retrieve(ctx)
 	log.Printf("[INFO] Retrieved credentials from %q", creds.Source)
 
-	var retryer aws.Retryer
-	retryer = retry.NewStandard()
-	if maxAttempts := os.Getenv("AWS_MAX_ATTEMPTS"); maxAttempts != "" {
-		if i, err := strconv.Atoi(maxAttempts); err == nil {
-			retryer = retry.AddWithMaxAttempts(retryer, i)
-		}
-	}
-	if c.MaxRetries != 0 {
-		retryer = retry.AddWithMaxAttempts(retryer, c.MaxRetries)
-	}
-	retryer = &networkErrorShortcutter{
-		Retryer: retryer,
-	}
-
 	loadOptions, err := commonLoadOptions(c)
 	if err != nil {
 		return aws.Config{}, err
@@ -63,9 +49,6 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 	loadOptions = append(
 		loadOptions,
 		config.WithCredentialsProvider(credentialsProvider),
-		config.WithRetryer(func() aws.Retryer {
-			return retryer
-		}),
 	)
 	if initialSource == ec2rolecreds.ProviderName {
 		loadOptions = append(
@@ -78,6 +61,8 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 		return awsConfig, fmt.Errorf("loading configuration: %w", err)
 	}
 
+	resolveRetryer(ctx, &awsConfig)
+
 	if !c.SkipCredsValidation {
 		if _, _, err := getAccountIDAndPartitionFromSTSGetCallerIdentity(ctx, stsClient(awsConfig, c)); err != nil {
 			return awsConfig, fmt.Errorf("error validating provider credentials: %w", err)
@@ -85,6 +70,25 @@ func GetAwsConfig(ctx context.Context, c *Config) (aws.Config, error) {
 	}
 
 	return awsConfig, nil
+}
+
+// Adapted from the per-service-client `resolveRetryer()` functions in the AWS SDK for Go v2
+// e.g. https://github.com/aws/aws-sdk-go-v2/blob/main/service/accessanalyzer/api_client.go
+// Currently only supports "standard" retry mode
+func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
+	var standardOptions []func(*retry.StandardOptions)
+
+	if v, found, _ := awsconfig.GetRetryMaxAttempts(ctx, awsConfig.ConfigSources); found && v != 0 {
+		standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
+			so.MaxAttempts = v
+		})
+	}
+
+	awsConfig.Retryer = func() aws.Retryer {
+		return &networkErrorShortcutter{
+			Retryer: retry.NewStandard(standardOptions...),
+		}
+	}
 }
 
 // networkErrorShortcutter is used to enable networking error shortcutting
@@ -174,6 +178,13 @@ func commonLoadOptions(c *Config) ([]func(*config.LoadOptions) error, error) {
 		config.WithHTTPClient(httpClient),
 		config.WithAPIOptions(apiOptions),
 		config.WithEC2IMDSClientEnableState(c.EC2MetadataServiceEnableState),
+	}
+
+	if c.MaxRetries != 0 {
+		loadOptions = append(
+			loadOptions,
+			config.WithRetryMaxAttempts(c.MaxRetries),
+		)
 	}
 
 	if !c.SuppressDebugLog {

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -1543,17 +1543,17 @@ func TestMaxAttempts(t *testing.T) {
 			ExpectedMaxAttempts: 5,
 		},
 
-		// 		"shared configuration file": {
-		// 			Config: &Config{
-		// 				AccessKey: servicemocks.MockStaticAccessKey,
-		// 				SecretKey: servicemocks.MockStaticSecretKey,
-		// 			},
-		// 			SharedConfigurationFile: `
-		// [default]
-		// max_attempts = 5
-		// `,
-		// 			ExpectedMaxAttempts: 5,
-		// 		},
+		"shared configuration file": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SharedConfigurationFile: `
+[default]
+max_attempts = 5
+`,
+			ExpectedMaxAttempts: 5,
+		},
 
 		"config overrides AWS_MAX_ATTEMPTS": {
 			Config: &Config{
@@ -1567,20 +1567,20 @@ func TestMaxAttempts(t *testing.T) {
 			ExpectedMaxAttempts: 10,
 		},
 
-		// 		"AWS_MAX_ATTEMPTS overrides shared configuration": {
-		// 			Config: &Config{
-		// 				AccessKey: servicemocks.MockStaticAccessKey,
-		// 				SecretKey: servicemocks.MockStaticSecretKey,
-		// 			},
-		// 			EnvironmentVariables: map[string]string{
-		// 				"AWS_MAX_ATTEMPTS": "5",
-		// 			},
-		// 			SharedConfigurationFile: `
-		// [default]
-		// max_attempts = 10
-		// `,
-		// 			ExpectedMaxAttempts: 5,
-		// 		},
+		"AWS_MAX_ATTEMPTS overrides shared configuration": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_MAX_ATTEMPTS": "5",
+			},
+			SharedConfigurationFile: `
+[default]
+max_attempts = 10
+`,
+			ExpectedMaxAttempts: 5,
+		},
 	}
 
 	for testName, testCase := range testCases {

--- a/internal/awsconfig/resolvers.go
+++ b/internal/awsconfig/resolvers.go
@@ -145,3 +145,21 @@ func EC2IMDSEndpointModeString(state imds.EndpointModeState) string {
 	}
 	return fmt.Sprintf("unknown imds.EndpointModeState (%d)", state)
 }
+
+// Copied and renamed from https://github.com/aws/aws-sdk-go-v2/blob/main/config/provider.go
+type RetryMaxAttemptsProvider interface {
+	GetRetryMaxAttempts(context.Context) (int, bool, error)
+}
+
+// Copied and renamed from https://github.com/aws/aws-sdk-go-v2/blob/main/config/provider.go
+func GetRetryMaxAttempts(ctx context.Context, sources []interface{}) (v int, found bool, err error) {
+	for _, c := range sources {
+		if p, ok := c.(RetryMaxAttemptsProvider); ok {
+			v, found, err = p.GetRetryMaxAttempts(ctx)
+			if err != nil || found {
+				break
+			}
+		}
+	}
+	return v, found, err
+}

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -19,9 +19,7 @@ type Partition struct {
 
 func (p Partition) Regions() []string {
 	rs := make([]string, len(p.p.regions))
-	for i, v := range p.p.regions {
-		rs[i] = v
-	}
+	copy(rs, p.p.regions)
 	return rs
 }
 

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -1363,17 +1363,17 @@ func TestMaxAttempts(t *testing.T) {
 			ExpectedMaxAttempts: 5,
 		},
 
-		// 		"shared configuration file": {
-		// 			Config: &awsbase.Config{
-		// 				AccessKey: servicemocks.MockStaticAccessKey,
-		// 				SecretKey: servicemocks.MockStaticSecretKey,
-		// 			},
-		// 			SharedConfigurationFile: `
-		// [default]
-		// max_attempts = 5
-		// `,
-		// 			ExpectedMaxAttempts: 5,
-		// 		},
+		"shared configuration file": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SharedConfigurationFile: `
+[default]
+max_attempts = 5
+`,
+			ExpectedMaxAttempts: 5,
+		},
 
 		"config overrides AWS_MAX_ATTEMPTS": {
 			Config: &awsbase.Config{
@@ -1387,20 +1387,20 @@ func TestMaxAttempts(t *testing.T) {
 			ExpectedMaxAttempts: 10,
 		},
 
-		// 		"AWS_MAX_ATTEMPTS overrides shared configuration": {
-		// 			Config: &awsbase.Config{
-		// 				AccessKey: servicemocks.MockStaticAccessKey,
-		// 				SecretKey: servicemocks.MockStaticSecretKey,
-		// 			},
-		// 			EnvironmentVariables: map[string]string{
-		// 				"AWS_MAX_ATTEMPTS": "5",
-		// 			},
-		// 			SharedConfigurationFile: `
-		// [default]
-		// max_attempts = 10
-		// `,
-		// 			ExpectedMaxAttempts: 5,
-		// 		},
+		"AWS_MAX_ATTEMPTS overrides shared configuration": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_MAX_ATTEMPTS": "5",
+			},
+			SharedConfigurationFile: `
+[default]
+max_attempts = 10
+`,
+			ExpectedMaxAttempts: 5,
+		},
 	}
 
 	for testName, testCase := range testCases {


### PR DESCRIPTION
The maximum retry attempts can currently be set directly or by using the `AWS_MAX_ATTEMPTS` environment variable. Adds support for reading from the shared config file

Closes #114