### PR TITLE
Remove AWS SDKs from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     ignore:
+      - dependency-name: "github.com/aws/*"
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:
@@ -16,6 +17,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/v2/awsv1shim"
     ignore:
+      - dependency-name: "github.com/aws/*"
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:

--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ However, if changes are made to `aws-sdk-go-base`, both modules should be releas
     * For `awsv1shim`, use the form `v2/awsv1shim/vX.Y.Z`
 1. Close the associated GitHub milestone
 1. Create the releases on GitHub
+
+## AWS SDK Upgrade Policy
+
+`aws-sdk-go-base` will only upgrade AWS SDKs as needed to bring in bug fixes or required enhancements.
+This leaves software making use of this module free to manage their own SDK versions.


### PR DESCRIPTION
In order to allow software that uses this module to manage their own AWS SDK versions, this module will only upgrade AWS SDKs as needed for bug fixes or needed enhancements