### PR TITLE
Configurable HTTP client

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -150,9 +150,16 @@ func GetAwsAccountIDAndPartition(ctx context.Context, awsConfig aws.Config, c *C
 }
 
 func commonLoadOptions(c *Config) ([]func(*config.LoadOptions) error, error) {
-	httpClient, err := defaultHttpClient(c)
-	if err != nil {
-		return nil, err
+	var err error
+	var httpClient config.HTTPClient
+
+	if v := c.HTTPClient; v == nil {
+		httpClient, err = defaultHttpClient(c)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		httpClient = v
 	}
 
 	apiOptions := make([]func(*middleware.Stack) error, 0)

--- a/http_client.go
+++ b/http_client.go
@@ -1,32 +1,17 @@
 package awsbase
 
 import (
-	"fmt"
-	"net/http"
-	"net/url"
-
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/config"
 )
 
 func defaultHttpClient(c *config.Config) (*awshttp.BuildableClient, error) {
-	var err error
+	opts, err := c.HTTPTransportOptions()
+	if err != nil {
+		return nil, err
+	}
 
-	httpClient := awshttp.NewBuildableClient().
-		WithTransportOptions(func(tr *http.Transport) {
-			if c.Insecure {
-				tlsConfig := tr.TLSClientConfig
-				tlsConfig.InsecureSkipVerify = true
-			}
-			if c.HTTPProxy != "" {
-				var proxyUrl *url.URL
-				proxyUrl, parseErr := url.Parse(c.HTTPProxy)
-				if parseErr != nil {
-					err = fmt.Errorf("error parsing HTTP proxy URL: %w", parseErr)
-				}
-				tr.Proxy = http.ProxyURL(proxyUrl)
-			}
-		})
+	httpClient := awshttp.NewBuildableClient().WithTransportOptions(opts)
 
 	return httpClient, err
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -21,6 +22,7 @@ type Config struct {
 	EC2MetadataServiceEnableState  imds.ClientEnableState
 	EC2MetadataServiceEndpoint     string
 	EC2MetadataServiceEndpointMode string
+	HTTPClient                     *http.Client
 	HTTPProxy                      string
 	IamEndpoint                    string
 	Insecure                       bool

--- a/v2/awsv1shim/http_client.go
+++ b/v2/awsv1shim/http_client.go
@@ -1,41 +1,20 @@
 package awsv1shim
 
 import (
-	"crypto/tls"
-	"fmt"
 	"net/http"
-	"net/url"
 
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/config"
 	"github.com/hashicorp/go-cleanhttp"
 )
 
 func defaultHttpClient(c *config.Config) (*http.Client, error) {
+	opts, err := c.HTTPTransportOptions()
+	if err != nil {
+		return nil, err
+	}
+
 	httpClient := cleanhttp.DefaultPooledClient()
-	transport := httpClient.Transport.(*http.Transport)
-
-	transport.MaxIdleConnsPerHost = awshttp.DefaultHTTPTransportMaxIdleConnsPerHost
-
-	tlsConfig := transport.TLSClientConfig
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-		transport.TLSClientConfig = tlsConfig
-	}
-	tlsConfig.MinVersion = tls.VersionTLS12
-
-	if c.Insecure {
-		tlsConfig.InsecureSkipVerify = true
-	}
-
-	if c.HTTPProxy != "" {
-		proxyUrl, err := url.Parse(c.HTTPProxy)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing HTTP proxy URL: %w", err)
-		}
-
-		transport.Proxy = http.ProxyURL(proxyUrl)
-	}
+	opts(httpClient.Transport.(*http.Transport))
 
 	return httpClient, nil
 }

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -31,9 +31,12 @@ func getSessionOptions(awsC *awsv2.Config, c *awsbase.Config) (*session.Options,
 		return nil, fmt.Errorf("error resolving dual-stack endpoint configuration: %w", err)
 	}
 
-	httpClient, err := defaultHttpClient(c)
-	if err != nil {
-		return nil, err
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient, err = defaultHttpClient(c)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	options := &session.Options{


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes https://github.com/hashicorp/aws-sdk-go-base/issues/323.

Adds an [`http.Client`](https://pkg.go.dev/net/http#Client) property to the `Config` object which is used for both AWS SDK v1 and SDKv2 API clients.
