### PR TITLE
docs: update required go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In order to assist with migrating large code bases using the AWS SDK for Go v1, 
 
 ## Requirements
 
-* [Go](https://golang.org/doc/install) 1.16
+* [Go](https://golang.org/doc/install) 1.18
 
 ## Development
 


### PR DESCRIPTION
Updates the README to reflect the Go version specified in `go.mod`

https://github.com/hashicorp/aws-sdk-go-base/blob/e22e988359fa4c2b505104824e6088b0bb5f51e4/go.mod#L35
