### PR TITLE
Removes no-op retryer for authentication

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -26,10 +26,6 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 	}
 	loadOptions = append(
 		loadOptions,
-		// Bypass retries when validating authentication
-		config.WithRetryer(func() aws.Retryer {
-			return aws.NopRetryer{}
-		}),
 		// The endpoint resolver is added here instead of in commonLoadOptions() so that it
 		// is not included in the aws.Config returned to the caller
 		config.WithEndpointResolverWithOptions(credentialsEndpointResolver(ctx, c)),


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #342

Removes no-op retryer from authentication. Will now use the AWS SDK for Go v2 default or an overridden value set using the env var `AWS_MAX_ATTEMPTS` or the shared configuration file parameter `max_attempts`. Does not currently use the value configured by the provider parameter `max_retries`, because the default setting will take over 20 minutes to time out.
