### PR TITLE
Avoid retries on expired credentials

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -96,7 +96,7 @@ func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, 
 
 	if !c.SkipCredsValidation {
 		if _, _, err := getAccountIDAndPartitionFromSTSGetCallerIdentity(baseCtx, stsClient(baseCtx, awsConfig, c)); err != nil {
-			return ctx, awsConfig, fmt.Errorf("error validating provider credentials: %w", err)
+			return ctx, awsConfig, fmt.Errorf("validating provider credentials: %w", err)
 		}
 	}
 

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -321,6 +321,20 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
+			Description: "sts:GetCallerIdentity expired token with invalid response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredToken,
+			},
+			ErrCount: 1,
+		},
+		{
+			Description: "sts:GetCallerIdentity expired token with valid response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyExpiredToken,
+			},
+			ErrCount: 1,
+		},
+		{
 			Description: "sts:GetCallerIdentity success",
 			MockEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -321,16 +321,44 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Description: "sts:GetCallerIdentity expired token with invalid response",
+			Description: "sts:GetCallerIdentity ExpiredToken with invalid JSON response",
 			MockEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredToken,
 			},
 			ErrCount: 1,
 		},
 		{
-			Description: "sts:GetCallerIdentity expired token with valid response",
+			Description: "sts:GetCallerIdentity ExpiredToken with valid JSON response",
 			MockEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityValidBodyExpiredToken,
+			},
+			ErrCount: 1,
+		},
+		{
+			Description: "sts:GetCallerIdentity ExpiredTokenException with invalid JSON response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredTokenException,
+			},
+			ErrCount: 1,
+		},
+		{
+			Description: "sts:GetCallerIdentity ExpiredTokenException with valid JSON response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyExpiredTokenException,
+			},
+			ErrCount: 1,
+		},
+		{
+			Description: "sts:GetCallerIdentity RequestExpired with invalid JSON response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyRequestExpired,
+			},
+			ErrCount: 1,
+		},
+		{
+			Description: "sts:GetCallerIdentity RequestExpired with valid JSON response",
+			MockEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyRequestExpired,
 			},
 			ErrCount: 1,
 		},

--- a/servicemocks/mock.go
+++ b/servicemocks/mock.go
@@ -114,6 +114,24 @@ const (
 </Error>
 <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
 </ErrorResponse>`
+	MockStsGetCallerIdentityValidResponseBodyExpiredToken = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>ExpiredToken</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<ResponseMetadata>
+  <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</ErrorResponse>`
+	MockStsGetCallerIdentityInvalidResponseBodyExpiredToken = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>ExpiredToken</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ErrorResponse>`
 	MockStsGetCallerIdentityPartition         = `aws`
 	MockStsGetCallerIdentityValidResponseBody = `<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult>
@@ -207,6 +225,36 @@ var (
 		},
 		Response: &MockResponse{
 			Body:        MockStsGetCallerIdentityInvalidResponseBodyAccessDenied,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityInvalidBodyExpiredToken = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityInvalidResponseBodyExpiredToken,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityValidBodyExpiredToken = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityValidResponseBodyExpiredToken,
 			ContentType: "text/xml",
 			StatusCode:  http.StatusForbidden,
 		},

--- a/servicemocks/mock.go
+++ b/servicemocks/mock.go
@@ -114,6 +114,8 @@ const (
 </Error>
 <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
 </ErrorResponse>`
+	// MockStsGetCallerIdentityValidResponseBodyExpiredToken uses code "ExpiredToken", seemingly the most common
+	// code. Errors usually have an invalid body but this may be fixed at some point.
 	MockStsGetCallerIdentityValidResponseBodyExpiredToken = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
 <Error>
   <Type>Sender</Type>
@@ -124,10 +126,56 @@ const (
   <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
 </ResponseMetadata>
 </ErrorResponse>`
+	// MockStsGetCallerIdentityInvalidResponseBodyExpiredToken uses code "ExpiredToken", seemingly the most common
+	// code. Errors usually have an invalid body.
 	MockStsGetCallerIdentityInvalidResponseBodyExpiredToken = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
 <Error>
   <Type>Sender</Type>
   <Code>ExpiredToken</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ErrorResponse>`
+	// MockStsGetCallerIdentityValidResponseBodyExpiredTokenException uses code "ExpiredTokenException", a more rare code
+	// but used at least by Fargate. Errors usually have an invalid body but this may change.
+	MockStsGetCallerIdentityValidResponseBodyExpiredTokenException = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>ExpiredTokenException</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<ResponseMetadata>
+  <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</ErrorResponse>`
+	// MockStsGetCallerIdentityInvalidResponseBodyExpiredTokenException uses code "ExpiredTokenException", a more rare code
+	// but used at least by Fargate. Errors usually have an invalid body but this may change.
+	MockStsGetCallerIdentityInvalidResponseBodyExpiredTokenException = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>ExpiredTokenException</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ErrorResponse>`
+	// MockStsGetCallerIdentityValidResponseBodyRequestExpired uses code "RequestExpired", a code only used in EC2.
+	// Errors usually have an invalid body but this may change.
+	MockStsGetCallerIdentityValidResponseBodyRequestExpired = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>RequestExpired</Code>
+  <Message>The security token included in the request is expired</Message>
+</Error>
+<ResponseMetadata>
+  <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+</ResponseMetadata>
+</ErrorResponse>`
+	// MockStsGetCallerIdentityInvalidResponseBodyRequestExpired uses code "RequestExpired", a code only used in EC2.
+	// Errors usually have an invalid body but this may change.
+	MockStsGetCallerIdentityInvalidResponseBodyRequestExpired = `<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<Error>
+  <Type>Sender</Type>
+  <Code>RequestExpired</Code>
   <Message>The security token included in the request is expired</Message>
 </Error>
 <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
@@ -255,6 +303,66 @@ var (
 		},
 		Response: &MockResponse{
 			Body:        MockStsGetCallerIdentityValidResponseBodyExpiredToken,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityInvalidBodyExpiredTokenException = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityInvalidResponseBodyExpiredTokenException,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityValidBodyExpiredTokenException = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityValidResponseBodyExpiredTokenException,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityInvalidBodyRequestExpired = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityInvalidResponseBodyRequestExpired,
+			ContentType: "text/xml",
+			StatusCode:  http.StatusForbidden,
+		},
+	}
+	MockStsGetCallerIdentityValidBodyRequestExpired = &MockEndpoint{
+		Request: &MockRequest{
+			Body: url.Values{
+				"Action":  []string{"GetCallerIdentity"},
+				"Version": []string{"2011-06-15"},
+			}.Encode(),
+			Method: http.MethodPost,
+			Uri:    "/",
+		},
+		Response: &MockResponse{
+			Body:        MockStsGetCallerIdentityValidResponseBodyRequestExpired,
 			ContentType: "text/xml",
 			StatusCode:  http.StatusForbidden,
 		},

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -148,6 +148,13 @@ func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*se
 			})
 			r.Retryable = aws.Bool(false)
 		}
+
+		if r.IsErrorExpired() {
+			logger.Warn(ctx, "Disabling retries after next request due to expired credentials", map[string]any{
+				"error": r.Error,
+			})
+			r.Retryable = aws.Bool(false)
+		}
 	})
 
 	return sess, nil

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -129,9 +129,17 @@ func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*se
 	sess.Handlers.Retry.PushBack(func(r *request.Request) {
 		logger := logging.RetrieveLogger(r.Context())
 
+		if r.IsErrorExpired() {
+			logger.Warn(ctx, "Disabling retries after next request due to expired credentials", map[string]any{
+				"error": r.Error,
+			})
+			r.Retryable = aws.Bool(false)
+		}
+
 		if r.RetryCount < constants.MaxNetworkRetryCount {
 			return
 		}
+
 		// RequestError: send request failed
 		// caused by: Post https://FQDN/: dial tcp: lookup FQDN: no such host
 		if tfawserr.ErrMessageAndOrigErrContain(r.Error, request.ErrCodeRequestError, "send request failed", "no such host") {
@@ -144,13 +152,6 @@ func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*se
 		// caused by: Post https://FQDN/: dial tcp IPADDRESS:443: connect: connection refused
 		if tfawserr.ErrMessageAndOrigErrContain(r.Error, request.ErrCodeRequestError, "send request failed", "connection refused") {
 			logger.Warn(ctx, "Disabling retries after next request due to networking error", map[string]any{
-				"error": r.Error,
-			})
-			r.Retryable = aws.Bool(false)
-		}
-
-		if r.IsErrorExpired() {
-			logger.Warn(ctx, "Disabling retries after next request due to expired credentials", map[string]any{
 				"error": r.Error,
 			})
 			r.Retryable = aws.Bool(false)

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -881,7 +881,6 @@ region = us-east-1
 			Description: "expired token error",
 			ExpectedError: func(err error) bool {
 				return strings.Contains(err.Error(), "ExpiredToken")
-				//return tfawserr.ErrCodeEquals(err, "ExpiredToken")
 			},
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredToken,

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -561,7 +561,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 [default]
 aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
-		`,
+`,
 		},
 		{
 			Config: &awsbase.Config{
@@ -872,6 +872,22 @@ region = us-east-1
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "expired token error",
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "ExpiredToken")
+				//return tfawserr.ErrCodeEquals(err, "ExpiredToken")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredToken,
+			},
+		},
+
 		// 		{
 		// 			Config: &awsbase.Config{
 		// 				AccessKey: servicemocks.MockStaticAccessKey,

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -878,7 +878,7 @@ region = us-east-1
 				Region:    "us-east-1",
 				SecretKey: servicemocks.MockStaticSecretKey,
 			},
-			Description: "expired token error",
+			Description: "ExpiredToken invalid body",
 			ExpectedError: func(err error) bool {
 				return strings.Contains(err.Error(), "ExpiredToken")
 			},
@@ -886,7 +886,76 @@ region = us-east-1
 				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredToken,
 			},
 		},
-
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "ExpiredToken valid body", // in case they change it
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "ExpiredToken")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyExpiredToken,
+			},
+		},
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "ExpiredTokenException invalid body",
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "ExpiredTokenException")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyExpiredTokenException,
+			},
+		},
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "ExpiredTokenException valid body", // in case they change it
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "ExpiredTokenException")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyExpiredTokenException,
+			},
+		},
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "RequestExpired invalid body",
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "RequestExpired")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityInvalidBodyRequestExpired,
+			},
+		},
+		{
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			Description: "RequestExpired valid body", // in case they change it
+			ExpectedError: func(err error) bool {
+				return strings.Contains(err.Error(), "RequestExpired")
+			},
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidBodyRequestExpired,
+			},
+		},
 		// 		{
 		// 			Config: &awsbase.Config{
 		// 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -1133,7 +1202,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 					t.Fatalf("unexpected GetAwsConfig() '%[1]T' error: %[1]s", err)
 				}
 
-				t.Logf("received expected error: %s", err)
+				t.Logf("received expected error (awsbase.GetAwsConfig): %s", err)
 				return
 			}
 			actualSession, err := GetSession(ctx, &awsConfig, testCase.Config)
@@ -1146,7 +1215,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 					t.Fatalf("unexpected GetSession() '%[1]T' error: %[1]s", err)
 				}
 
-				t.Logf("received expected error: %s", err)
+				t.Logf("received expected error (GetSession): %s", err)
 				return
 			}
 
@@ -2299,6 +2368,27 @@ func TestSessionRetryHandlers(t *testing.T) {
 			Error:                    errors.New("some error"),
 			ExpectedRetryableValue:   true,  // defaults to true for non-AWS errors
 			ExpectRetryToBeAttempted: false, // Does not actually get retried, because over max retry limit
+		},
+		{
+			Description:              "ExpiredToken error no retries",
+			RetryCount:               maxRetries,
+			Error:                    awserr.New("ExpiredToken", "The security token included in the request is expired", nil),
+			ExpectedRetryableValue:   false,
+			ExpectRetryToBeAttempted: false,
+		},
+		{
+			Description:              "ExpiredTokenException error no retries",
+			RetryCount:               maxRetries,
+			Error:                    awserr.New("ExpiredTokenException", "The security token included in the request is expired", nil),
+			ExpectedRetryableValue:   false,
+			ExpectRetryToBeAttempted: false,
+		},
+		{
+			Description:              "RequestExpired error no retries",
+			RetryCount:               maxRetries,
+			Error:                    awserr.New("RequestExpired", "The security token included in the request is expired", nil),
+			ExpectedRetryableValue:   false,
+			ExpectRetryToBeAttempted: false,
 		},
 		{
 			Description:              "send request no such host failed under MaxNetworkRetryCount",


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes: #23 
Closes: #363

Closes: hashicorp/terraform-provider-aws#6992

To avoid retry/backoff causing long or terminal delays in reporting the expired credentials error, stop retrying when this error is encountered.

**Note:** https://github.com/hashicorp/aws-sdk-go-base/pull/23 and https://github.com/hashicorp/terraform-provider-aws/pull/6992 take the approach of adding a flag to avoid this retrying behavior. However, after discussions with the AWS Provider team, security, and a former AWS Provider engineer, there appears to be no situation in which an expired credential would ever become unexpired. In other words, long retrying efforts are a bug that can be fixed without adding a new flag (e.g., `stop_on_expired_creds`).
