### PR TITLE
Add strict checking of AWS API mock endpoints.

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -92,6 +92,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -157,6 +158,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -175,6 +177,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"ExternalId": servicemocks.MockStsAssumeRoleExternalId}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"ExternalId": servicemocks.MockStsAssumeRoleExternalId}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -195,6 +198,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": servicemocks.MockStsAssumeRolePolicy}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": servicemocks.MockStsAssumeRolePolicy}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -213,6 +217,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"PolicyArns.member.1.arn": servicemocks.MockStsAssumeRolePolicyArn}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"PolicyArns.member.1.arn": servicemocks.MockStsAssumeRolePolicyArn}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -234,6 +239,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -257,6 +263,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue, "TransitiveTagKeys.member.1": servicemocks.MockStsAssumeRoleTagKey}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue, "TransitiveTagKeys.member.1": servicemocks.MockStsAssumeRoleTagKey}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -275,6 +282,7 @@ func TestGetAwsConfig(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"SourceIdentity": servicemocks.MockStsAssumeRoleSourceIdentity}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"SourceIdentity": servicemocks.MockStsAssumeRoleSourceIdentity}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -402,6 +410,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -553,6 +562,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 			SharedCredentialsFile: `
@@ -600,6 +610,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -629,6 +640,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:             "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -647,6 +659,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -664,6 +677,8 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -2396,6 +2411,7 @@ func TestAssumeRole(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 			},
 		},
 
@@ -2439,6 +2455,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 			},
 		},
 
@@ -2455,6 +2472,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
 			},
 		},
 
@@ -2470,6 +2488,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": "{}"}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": "{}"}),
 			},
 		},
@@ -2583,6 +2602,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
 
@@ -2596,6 +2616,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			SetConfig:                true,
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2611,6 +2632,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			ExpandEnvVars:            true,
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2657,6 +2679,7 @@ role_session_name = %[2]s
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2711,6 +2734,7 @@ web_identity_token_file = no-such-file
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
 
@@ -2726,6 +2750,7 @@ web_identity_token_file = no-such-file
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"DurationSeconds": "3600"}),
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"DurationSeconds": "3600"}),
 			},
 		},
 
@@ -2740,6 +2765,7 @@ web_identity_token_file = no-such-file
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"Policy": "{}"}),
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"Policy": "{}"}),
 			},
 		},
@@ -2901,6 +2927,7 @@ func TestGetAwsConfigWithAccountIDAndPartition(t *testing.T) {
 			expectedAcctID: "222222222222", expectedPartition: "aws",
 			mockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
 		{
@@ -2940,6 +2967,8 @@ func TestGetAwsConfigWithAccountIDAndPartition(t *testing.T) {
 			expectedAcctID: "555555555555", expectedPartition: "aws",
 			mockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
 			},
 		},
@@ -3301,6 +3330,7 @@ func TestLogger(t *testing.T) {
 	}
 
 	mockStsEndpoints := []*servicemocks.MockEndpoint{
+		servicemocks.MockStsGetCallerIdentityValidEndpoint,
 		servicemocks.MockStsGetCallerIdentityValidEndpoint,
 	}
 	ts := servicemocks.MockAwsApiServer("STS", &mockStsEndpoints)

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -123,10 +123,10 @@ func TestGetAccountIDAndPartition(t *testing.T) {
 			awsTs := servicemocks.AwsMetadataApiMock(testCase.EC2MetadataEndpoints)
 			defer awsTs()
 
-			closeIam, iamConfig, _ := mockdata.GetMockedAwsApiSession("IAM", testCase.IAMEndpoints)
+			closeIam, iamConfig, _ := mockdata.GetMockedAwsApiSession("IAM", &testCase.IAMEndpoints)
 			defer closeIam()
 
-			closeSts, stsConfig, _ := mockdata.GetMockedAwsApiSession("STS", testCase.STSEndpoints)
+			closeSts, stsConfig, _ := mockdata.GetMockedAwsApiSession("STS", &testCase.STSEndpoints)
 			defer closeSts()
 
 			iamConn := iam.NewFromConfig(iamConfig)
@@ -144,6 +144,15 @@ func TestGetAccountIDAndPartition(t *testing.T) {
 			}
 			if partition != testCase.ExpectedPartition {
 				t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+			}
+
+			numMockIamEndpoints := len(testCase.IAMEndpoints)
+			if numMockIamEndpoints > 0 {
+				t.Fatalf("expected all mock IAM endpoints exhausted, remaining: %d", numMockIamEndpoints)
+			}
+			numMockStsEndpoints := len(testCase.STSEndpoints)
+			if numMockStsEndpoints > 0 {
+				t.Fatalf("expected all mock STS endpoints exhausted, remaining: %d", numMockStsEndpoints)
 			}
 		})
 	}
@@ -224,7 +233,7 @@ func TestGetAccountIDAndPartitionFromIAMGetUser(t *testing.T) {
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
-			closeIam, config, _ := mockdata.GetMockedAwsApiSession("IAM", testCase.MockEndpoints)
+			closeIam, config, _ := mockdata.GetMockedAwsApiSession("IAM", &testCase.MockEndpoints)
 			defer closeIam()
 
 			iamClient := iam.NewFromConfig(config)
@@ -241,6 +250,11 @@ func TestGetAccountIDAndPartitionFromIAMGetUser(t *testing.T) {
 			}
 			if partition != testCase.ExpectedPartition {
 				t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+			}
+
+			numMockIamEndpoints := len(testCase.MockEndpoints)
+			if numMockIamEndpoints > 0 {
+				t.Fatalf("expected all mock IAM endpoints exhausted, remaining: %d", numMockIamEndpoints)
 			}
 		})
 	}
@@ -283,7 +297,7 @@ func TestGetAccountIDAndPartitionFromIAMListRoles(t *testing.T) {
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
-			closeIam, config, _ := mockdata.GetMockedAwsApiSession("IAM", testCase.MockEndpoints)
+			closeIam, config, _ := mockdata.GetMockedAwsApiSession("IAM", &testCase.MockEndpoints)
 			defer closeIam()
 
 			iamClient := iam.NewFromConfig(config)
@@ -300,6 +314,11 @@ func TestGetAccountIDAndPartitionFromIAMListRoles(t *testing.T) {
 			}
 			if partition != testCase.ExpectedPartition {
 				t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+			}
+
+			numMockIamEndpoints := len(testCase.MockEndpoints)
+			if numMockIamEndpoints > 0 {
+				t.Fatalf("expected all mock IAM endpoints exhausted, remaining: %d", numMockIamEndpoints)
 			}
 		})
 	}
@@ -378,7 +397,7 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
-			closeSts, config, _ := mockdata.GetMockedAwsApiSession("STS", testCase.MockEndpoints)
+			closeSts, config, _ := mockdata.GetMockedAwsApiSession("STS", &testCase.MockEndpoints)
 			defer closeSts()
 
 			stsClient := sts.NewFromConfig(config)
@@ -395,6 +414,11 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 			}
 			if partition != testCase.ExpectedPartition {
 				t.Fatalf("Parsed partition doesn't match with expected (%q != %q)", partition, testCase.ExpectedPartition)
+			}
+
+			numMockIamEndpoints := len(testCase.MockEndpoints)
+			if numMockIamEndpoints > 0 {
+				t.Fatalf("expected all mock IAM endpoints exhausted, remaining: %d", numMockIamEndpoints)
 			}
 		})
 	}

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -30,26 +30,15 @@ func TestGetAccountIDAndPartition(t *testing.T) {
 			Description:          "EC2 Metadata over iam:GetUser when using EC2 Instance Profile",
 			AuthProviderName:     ec2rolecreds.ProviderName,
 			EC2MetadataEndpoints: append(servicemocks.Ec2metadata_securityCredentialsEndpoints, servicemocks.Ec2metadata_instanceIdEndpoint, servicemocks.Ec2metadata_iamInfoEndpoint),
-
-			IAMEndpoints: []*servicemocks.MockEndpoint{
-				{
-					Request:  &servicemocks.MockRequest{Method: "POST", Uri: "/", Body: "Action=GetUser&Version=2010-05-08"},
-					Response: &servicemocks.MockResponse{StatusCode: http.StatusOK, Body: servicemocks.IamResponse_GetUser_valid, ContentType: "text/xml"},
-				},
-			},
-			ExpectedAccountID: servicemocks.Ec2metadata_iamInfoEndpoint_expectedAccountID,
-			ExpectedPartition: servicemocks.Ec2metadata_iamInfoEndpoint_expectedPartition,
+			IAMEndpoints:         []*servicemocks.MockEndpoint{},
+			ExpectedAccountID:    servicemocks.Ec2metadata_iamInfoEndpoint_expectedAccountID,
+			ExpectedPartition:    servicemocks.Ec2metadata_iamInfoEndpoint_expectedPartition,
 		},
 		{
 			Description:          "Mimic the metadata service mocked by Hologram (https://github.com/AdRoll/hologram)",
 			AuthProviderName:     ec2rolecreds.ProviderName,
 			EC2MetadataEndpoints: servicemocks.Ec2metadata_securityCredentialsEndpoints,
-			IAMEndpoints: []*servicemocks.MockEndpoint{
-				{
-					Request:  &servicemocks.MockRequest{Method: "POST", Uri: "/", Body: "Action=GetUser&Version=2010-05-08"},
-					Response: &servicemocks.MockResponse{StatusCode: http.StatusForbidden, Body: servicemocks.IamResponse_GetUser_unauthorized, ContentType: "text/xml"},
-				},
-			},
+			IAMEndpoints:         []*servicemocks.MockEndpoint{},
 			STSEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -215,7 +215,7 @@ func TestAWSGetCredentials_webIdentityToken(t *testing.T) {
 
 	mockStsEndpoints := []*servicemocks.MockEndpoint{
 		servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
-		servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
+		servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 	}
 	ts := servicemocks.MockAwsApiServer("STS", &mockStsEndpoints)
 	defer ts.Close()
@@ -260,7 +260,7 @@ func TestAWSGetCredentials_assumeRole(t *testing.T) {
 
 	mockStsEndpoints := []*servicemocks.MockEndpoint{
 		servicemocks.MockStsAssumeRoleValidEndpoint,
-		servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
+		servicemocks.MockStsAssumeRoleValidEndpoint,
 	}
 	ts := servicemocks.MockAwsApiServer("STS", &mockStsEndpoints)
 	defer ts.Close()

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -213,10 +213,11 @@ func TestAWSGetCredentials_webIdentityToken(t *testing.T) {
 		},
 	}
 
-	ts := servicemocks.MockAwsApiServer("STS", []*servicemocks.MockEndpoint{
+	mockStsEndpoints := []*servicemocks.MockEndpoint{
 		servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 		servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
-	})
+	}
+	ts := servicemocks.MockAwsApiServer("STS", &mockStsEndpoints)
 	defer ts.Close()
 	cfg.StsEndpoint = ts.URL
 
@@ -235,6 +236,11 @@ func TestAWSGetCredentials_webIdentityToken(t *testing.T) {
 		servicemocks.MockStsAssumeRoleWithWebIdentitySessionToken,
 		stscreds.WebIdentityProviderName, t)
 	testCredentialsProviderWrappedWithCache(creds, t)
+
+	numMockStsEndpoints := len(mockStsEndpoints)
+	if numMockStsEndpoints > 0 {
+		t.Errorf("expected all mock endpoints exhausted, remaining: %d", numMockStsEndpoints)
+	}
 }
 
 func TestAWSGetCredentials_assumeRole(t *testing.T) {
@@ -252,10 +258,11 @@ func TestAWSGetCredentials_assumeRole(t *testing.T) {
 		},
 	}
 
-	ts := servicemocks.MockAwsApiServer("STS", []*servicemocks.MockEndpoint{
+	mockStsEndpoints := []*servicemocks.MockEndpoint{
 		servicemocks.MockStsAssumeRoleValidEndpoint,
 		servicemocks.MockStsGetCallerIdentityValidAssumedRoleEndpoint,
-	})
+	}
+	ts := servicemocks.MockAwsApiServer("STS", &mockStsEndpoints)
 	defer ts.Close()
 	cfg.StsEndpoint = ts.URL
 
@@ -274,6 +281,11 @@ func TestAWSGetCredentials_assumeRole(t *testing.T) {
 		servicemocks.MockStsAssumeRoleSessionToken,
 		stscreds.ProviderName, t)
 	testCredentialsProviderWrappedWithCache(creds, t)
+
+	numMockStsEndpoints := len(mockStsEndpoints)
+	if numMockStsEndpoints > 0 {
+		t.Errorf("expected all mock endpoints exhausted, remaining: %d", numMockStsEndpoints)
+	}
 }
 
 var credentialsFileContentsEnv = `[myprofile]

--- a/mockdata/mocks.go
+++ b/mockdata/mocks.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetMockedAwsApiSession establishes an AWS session to a simulated AWS API server for a given service and route endpoints.
-func GetMockedAwsApiSession(svcName string, endpoints []*servicemocks.MockEndpoint) (func(), aws.Config, string) {
+func GetMockedAwsApiSession(svcName string, endpoints *[]*servicemocks.MockEndpoint) (func(), aws.Config, string) {
 	ts := servicemocks.MockAwsApiServer(svcName, endpoints)
 
 	sc := credentials.NewStaticCredentialsProvider("accessKey", "secretKey", "")

--- a/servicemocks/mock.go
+++ b/servicemocks/mock.go
@@ -400,7 +400,7 @@ var (
 )
 
 // MockAwsApiServer establishes a httptest server to simulate behaviour of a real AWS API server
-func MockAwsApiServer(svcName string, endpoints []*MockEndpoint) *httptest.Server {
+func MockAwsApiServer(svcName string, endpoints *[]*MockEndpoint) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)
 		if _, err := buf.ReadFrom(r.Body); err != nil {
@@ -413,19 +413,21 @@ func MockAwsApiServer(svcName string, endpoints []*MockEndpoint) *httptest.Serve
 		log.Printf("[DEBUG] Received %s API %q request to %q: %s",
 			svcName, r.Method, r.RequestURI, requestBody)
 
-		for _, e := range endpoints {
-			if r.Method == e.Request.Method && r.RequestURI == e.Request.Uri && requestBody == e.Request.Body {
-				log.Printf("[DEBUG] Mocked %s API responding with %d: %s",
-					svcName, e.Response.StatusCode, e.Response.Body)
+		e := (*endpoints)[0]
+		log.Printf("[DEBUG2] checking endpoint: %s", e.Request.Body)
+		if r.Method == e.Request.Method && r.RequestURI == e.Request.Uri && requestBody == e.Request.Body {
+			log.Printf("[DEBUG] Mocked %s API responding with %d: %s",
+				svcName, e.Response.StatusCode, e.Response.Body)
 
-				w.WriteHeader(e.Response.StatusCode)
-				w.Header().Set("Content-Type", e.Response.ContentType)
-				w.Header().Set("X-Amzn-Requestid", "1b206dd1-f9a8-11e5-becf-051c60f11c4a")
-				w.Header().Set("Date", time.Now().Format(time.RFC1123))
+			w.WriteHeader(e.Response.StatusCode)
+			w.Header().Set("Content-Type", e.Response.ContentType)
+			w.Header().Set("X-Amzn-Requestid", "1b206dd1-f9a8-11e5-becf-051c60f11c4a")
+			w.Header().Set("Date", time.Now().Format(time.RFC1123))
 
-				fmt.Fprintln(w, e.Response.Body)
-				return
-			}
+			fmt.Fprintln(w, e.Response.Body)
+
+			*endpoints = (*endpoints)[1:]
+			return
 		}
 
 		w.WriteHeader(http.StatusBadRequest)

--- a/v2/awsv1shim/mockdata/mocks.go
+++ b/v2/awsv1shim/mockdata/mocks.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetMockedAwsApiSession establishes an AWS session to a simulated AWS API server for a given service and route endpoints.
-func GetMockedAwsApiSession(svcName string, endpoints []*servicemocks.MockEndpoint) (func(), *session.Session, error) {
+func GetMockedAwsApiSession(svcName string, endpoints *[]*servicemocks.MockEndpoint) (func(), *session.Session, error) {
 	ts := servicemocks.MockAwsApiServer(svcName, endpoints)
 
 	sc := credentials.NewStaticCredentials("accessKey", "secretKey", "")

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -140,6 +140,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -158,6 +159,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -178,6 +180,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"ExternalId": servicemocks.MockStsAssumeRoleExternalId}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"ExternalId": servicemocks.MockStsAssumeRoleExternalId}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -197,6 +200,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": servicemocks.MockStsAssumeRolePolicy}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": servicemocks.MockStsAssumeRolePolicy}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -215,6 +219,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"PolicyArns.member.1.arn": servicemocks.MockStsAssumeRolePolicyArn}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"PolicyArns.member.1.arn": servicemocks.MockStsAssumeRolePolicyArn}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -236,6 +241,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -259,6 +265,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue, "TransitiveTagKeys.member.1": servicemocks.MockStsAssumeRoleTagKey}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Tags.member.1.Key": servicemocks.MockStsAssumeRoleTagKey, "Tags.member.1.Value": servicemocks.MockStsAssumeRoleTagValue, "TransitiveTagKeys.member.1": servicemocks.MockStsAssumeRoleTagKey}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -277,6 +284,7 @@ func TestGetSession(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"SourceIdentity": servicemocks.MockStsAssumeRoleSourceIdentity}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"SourceIdentity": servicemocks.MockStsAssumeRoleSourceIdentity}),
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -404,6 +412,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -555,6 +564,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 			SharedCredentialsFile: `
@@ -602,6 +612,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -631,6 +642,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:             "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -649,6 +661,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
 		},
@@ -666,6 +679,8 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 			ExpectedRegion:           "us-east-1",
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsAssumeRoleValidEndpoint,
 				servicemocks.MockStsGetCallerIdentityValidEndpoint,
 			},
@@ -1543,9 +1558,7 @@ use_fips_endpoint = true
 				os.Setenv(k, v)
 			}
 
-			mockStsEndpoints := []*servicemocks.MockEndpoint{
-				servicemocks.MockStsGetCallerIdentityValidEndpoint,
-     }
+			mockStsEndpoints := []*servicemocks.MockEndpoint{}
 			closeSts, mockStsSession, err := mockdata.GetMockedAwsApiSession("STS", &mockStsEndpoints)
 			defer closeSts()
 
@@ -1842,6 +1855,7 @@ func TestAssumeRole(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 			},
 		},
 
@@ -1885,6 +1899,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpoint,
+				servicemocks.MockStsAssumeRoleValidEndpoint,
 			},
 		},
 
@@ -1901,6 +1916,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"DurationSeconds": "3600"}),
 			},
 		},
 
@@ -1916,6 +1932,7 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": "{}"}),
 				servicemocks.MockStsAssumeRoleValidEndpointWithOptions(map[string]string{"Policy": "{}"}),
 			},
 		},
@@ -2049,6 +2066,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
 
@@ -2062,6 +2080,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			SetConfig:                true,
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2077,6 +2096,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 			ExpandEnvVars:            true,
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2123,6 +2143,7 @@ role_session_name = %[2]s
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
@@ -2177,6 +2198,7 @@ web_identity_token_file = no-such-file
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidEndpoint,
 			},
 		},
 
@@ -2192,6 +2214,7 @@ web_identity_token_file = no-such-file
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"DurationSeconds": "3600"}),
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"DurationSeconds": "3600"}),
 			},
 		},
 
@@ -2206,6 +2229,7 @@ web_identity_token_file = no-such-file
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
 			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"Policy": "{}"}),
 				servicemocks.MockStsAssumeRoleWithWebIdentityValidWithOptions(map[string]string{"Policy": "{}"}),
 			},
 		},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

References: #369. (This PR updates the existing test suite to assert on mock API counts. These count assertions can then be used to replicate the scenario mentioned in #369.)

---

Previously, an unordered list of endpoint definitions were provided to the mock API server and incoming requests were matched with a simple existence lookup.

Now:

 - the list is ordered and requests are matched in FIFO order (i.e. any out-of-sequence request will be returned a HTTP 400); and,
 - matched requests will be shifted off the list (to avoid being matched multiple times); and,
 - every test scenario will additionally check that the list of expected endpoints for that scenario is fully exhausted.

Ultimately, the result is that each test scenario must **exactly** match the list of expected endpoints - no more and no less.

The objective is to expose duplicated API calls that are not only inefficient, but also potentially cause the API service to rate-limit (see https://github.com/hashicorp/terraform-provider-aws/issues/27071).
