### PR TITLE
Use `container: returntocorp/semgrep` instead of GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,11 +63,12 @@ jobs:
 
   semgrep:
     runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
     steps:
       - uses: actions/checkout@v3
 
-      - name: semgrep
-        uses: returntocorp/semgrep-action@v1
+      - run: semgrep --error --quiet --config .semgrep
         env:
           REWRITE_RULE_IDS: 0
 


### PR DESCRIPTION
Use `container: returntocorp/semgrep` instead of action to follow recommended practice: 

> This wrapper script is deprecated. It is recommended to stop using this wrapper script and migrate to native Semgrep support instead. Refer to the [GitHub Actions configuration document](https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#sample-github-actions-configuration-file).

(https://github.com/marketplace/actions/semgrep-action)