### PR TITLE
Add support for retry mode

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -293,7 +293,7 @@ func commonLoadOptions(ctx context.Context, c *Config) ([]func(*config.LoadOptio
 			config.WithEC2IMDSEndpoint(c.EC2MetadataServiceEndpoint),
 		)
 	}
-	
+
 	if c.RetryMode != "" {
 		loadOptions = append(loadOptions,
 			config.WithRetryMode(c.RetryMode),

--- a/aws_config.go
+++ b/aws_config.go
@@ -293,6 +293,12 @@ func commonLoadOptions(ctx context.Context, c *Config) ([]func(*config.LoadOptio
 			config.WithEC2IMDSEndpoint(c.EC2MetadataServiceEndpoint),
 		)
 	}
+	
+	if c.RetryMode != "" {
+		loadOptions = append(loadOptions,
+			config.WithRetryMode(c.RetryMode),
+		)
+	}
 
 	if c.EC2MetadataServiceEndpointMode != "" {
 		var endpointMode imds.EndpointModeState

--- a/aws_config.go
+++ b/aws_config.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -112,21 +113,59 @@ func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, 
 
 // Adapted from the per-service-client `resolveRetryer()` functions in the AWS SDK for Go v2
 // e.g. https://github.com/aws/aws-sdk-go-v2/blob/main/service/accessanalyzer/api_client.go
-// Currently only supports "standard" retry mode
 func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
-	var standardOptions []func(*retry.StandardOptions)
+	retryMode := awsConfig.RetryMode
+	if len(retryMode) == 0 {
+		defaultsMode := resolveDefaultsMode(ctx, awsConfig)
+		modeConfig, err := defaults.GetModeConfiguration(defaultsMode)
+		if err == nil {
+			retryMode = modeConfig.RetryMode
+		}
+	}
+	if len(retryMode) == 0 {
+		retryMode = aws.RetryModeStandard
+	}
 
+	var standardOptions []func(*retry.StandardOptions)
 	if v, found, _ := awsconfig.GetRetryMaxAttempts(ctx, awsConfig.ConfigSources); found && v != 0 {
 		standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
 			so.MaxAttempts = v
 		})
 	}
 
+	var retryer aws.RetryerV2
+	switch retryMode {
+	case aws.RetryModeAdaptive:
+		var adaptiveOptions []func(*retry.AdaptiveModeOptions)
+		if len(standardOptions) != 0 {
+			adaptiveOptions = append(adaptiveOptions, func(ao *retry.AdaptiveModeOptions) {
+				ao.StandardOptions = append(ao.StandardOptions, standardOptions...)
+			})
+		}
+		retryer = retry.NewAdaptiveMode(adaptiveOptions...)
+
+	default:
+		retryer = retry.NewStandard(standardOptions...)
+	}
+
 	awsConfig.Retryer = func() aws.Retryer {
 		return &networkErrorShortcutter{
-			RetryerV2: retry.NewStandard(standardOptions...),
+			RetryerV2: retryer,
 		}
 	}
+}
+
+// Adapted from the per-service-client `setResolvedDefaultsMode()` functions in the AWS SDK for Go v2
+// e.g. https://github.com/aws/aws-sdk-go-v2/blob/main/service/accessanalyzer/api_client.go
+func resolveDefaultsMode(_ context.Context, awsConfig *aws.Config) aws.DefaultsMode {
+	var mode aws.DefaultsMode
+	mode.SetFromString(string(awsConfig.DefaultsMode))
+
+	if mode == aws.DefaultsModeAuto {
+		mode = defaults.ResolveDefaultsModeAuto(awsConfig.Region, awsConfig.RuntimeEnvironment)
+	}
+
+	return mode
 }
 
 // networkErrorShortcutter is used to enable networking error shortcutting

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -1663,7 +1663,6 @@ func TestRetryMode(t *testing.T) {
 	}
 }
 
-
 func TestServiceEndpointTypes(t *testing.T) {
 	testCases := map[string]struct {
 		Config                            *Config

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -1544,6 +1544,126 @@ max_attempts = 10
 	}
 }
 
+func TestRetryMode(t *testing.T) {
+	testCases := map[string]struct {
+		Config                  *Config
+		EnvironmentVariables    map[string]string
+		SharedConfigurationFile string
+		ExpectedRetryMode       aws.RetryMode
+	}{
+		"no configuration": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			ExpectedRetryMode: "",
+		},
+
+		"config": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+				RetryMode: aws.RetryModeStandard,
+			},
+			ExpectedRetryMode: aws.RetryModeStandard,
+		},
+
+		"AWS_RETRY_MODE": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "adaptive",
+			},
+			ExpectedRetryMode: aws.RetryModeAdaptive,
+		},
+
+		"shared configuration file": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SharedConfigurationFile: `
+		[default]
+		retry_mode = standard
+		`,
+			ExpectedRetryMode: aws.RetryModeStandard,
+		},
+
+		"config overrides AWS_RETRY_MODE": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+				RetryMode: aws.RetryModeStandard,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "adaptive",
+			},
+			ExpectedRetryMode: aws.RetryModeStandard,
+		},
+
+		"AWS_RETRY_MODE overrides shared configuration": {
+			Config: &Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "standard",
+			},
+			SharedConfigurationFile: `
+		[default]
+		retry_mode = adaptive
+		`,
+			ExpectedRetryMode: aws.RetryModeStandard,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testName, func(t *testing.T) {
+			oldEnv := servicemocks.InitSessionTestEnv()
+			defer servicemocks.PopEnv(oldEnv)
+
+			for k, v := range testCase.EnvironmentVariables {
+				os.Setenv(k, v)
+			}
+
+			if testCase.SharedConfigurationFile != "" {
+				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = os.WriteFile(file.Name(), []byte(testCase.SharedConfigurationFile), 0600)
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				testCase.Config.SharedConfigFiles = []string{file.Name()}
+			}
+
+			testCase.Config.SkipCredsValidation = true
+
+			_, awsConfig, err := GetAwsConfig(context.Background(), testCase.Config)
+			if err != nil {
+				t.Fatalf("error in GetAwsConfig() '%[1]T': %[1]s", err)
+			}
+
+			retryMode := awsConfig.RetryMode
+			if a, e := retryMode, testCase.ExpectedRetryMode; a != e {
+				t.Errorf(`expected RetryMode "%s", got: "%s"`, e.String(), a.String())
+			}
+		})
+	}
+}
+
+
 func TestServiceEndpointTypes(t *testing.T) {
 	testCases := map[string]struct {
 		Config                            *Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/expand"
+	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MaxRetries                     int
 	Profile                        string
 	Region                         string
+	RetryMode                      string
 	SecretKey                      string
 	SharedCredentialsFiles         []string
 	SharedConfigFiles              []string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	MaxRetries                     int
 	Profile                        string
 	Region                         string
-	RetryMode                      string
+	RetryMode                      aws.RetryMode
 	SecretKey                      string
 	SharedCredentialsFiles         []string
 	SharedConfigFiles              []string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/expand"
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 type Config struct {

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	retryv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
 	retryModev2 "github.com/aws/aws-sdk-go-v2/aws"
+	retryv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
 	configv2 "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go/aws"

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	retryv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
+	retryModev2 "github.com/aws/aws-sdk-go-v2/aws"
 	configv2 "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go/aws"
@@ -1403,6 +1404,125 @@ max_attempts = 10
 
 			if a, e := *actualSession.Config.MaxRetries, testCase.ExpectedMaxAttempts; a != e {
 				t.Errorf(`expected MaxAttempts "%d", got: "%d"`, e, a)
+			}
+		})
+	}
+}
+
+func TestRetryMode(t *testing.T) {
+	testCases := map[string]struct {
+		Config                  *awsbase.Config
+		EnvironmentVariables    map[string]string
+		SharedConfigurationFile string
+		ExpectedRetryMode       retryModev2.RetryMode
+	}{
+		"no configuration": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			ExpectedRetryMode: "",
+		},
+
+		"config": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+				RetryMode: retryModev2.RetryModeStandard,
+			},
+			ExpectedRetryMode: retryModev2.RetryModeStandard,
+		},
+
+		"AWS_RETRY_MODE": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "adaptive",
+			},
+			ExpectedRetryMode: retryModev2.RetryModeAdaptive,
+		},
+
+		"shared configuration file": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SharedConfigurationFile: `
+		[default]
+		retry_mode = standard
+		`,
+			ExpectedRetryMode: retryModev2.RetryModeStandard,
+		},
+
+		"config overrides AWS_RETRY_MODE": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+				RetryMode: retryModev2.RetryModeStandard,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "adaptive",
+			},
+			ExpectedRetryMode: retryModev2.RetryModeStandard,
+		},
+
+		"AWS_RETRY_MODE overrides shared configuration": {
+			Config: &awsbase.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				"AWS_RETRY_MODE": "standard",
+			},
+			SharedConfigurationFile: `
+		[default]
+		retry_mode = adaptive
+		`,
+			ExpectedRetryMode: retryModev2.RetryModeStandard,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testName, func(t *testing.T) {
+			oldEnv := servicemocks.InitSessionTestEnv()
+			defer servicemocks.PopEnv(oldEnv)
+
+			for k, v := range testCase.EnvironmentVariables {
+				os.Setenv(k, v)
+			}
+
+			if testCase.SharedConfigurationFile != "" {
+				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = os.WriteFile(file.Name(), []byte(testCase.SharedConfigurationFile), 0600)
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				testCase.Config.SharedConfigFiles = []string{file.Name()}
+			}
+
+			testCase.Config.SkipCredsValidation = true
+
+			_, awsConfig, err := awsbase.GetAwsConfig(context.Background(), testCase.Config)
+			if err != nil {
+				t.Fatalf("error in GetAwsConfig() '%[1]T': %[1]s", err)
+			}
+
+			retryMode := awsConfig.RetryMode
+			if a, e := retryMode, testCase.ExpectedRetryMode; a != e {
+				t.Errorf(`expected RetryMode "%s", got: "%s"`, e.String(), a.String())
 			}
 		})
 	}


### PR DESCRIPTION
Add support for RetryMode via ENV variable, shared config and directly

Closes https://github.com/hashicorp/aws-sdk-go-base/issues/147