### PR TITLE
mask all sensitive values

### DIFF
--- a/logging/aws.go
+++ b/logging/aws.go
@@ -30,11 +30,6 @@ func MaskAWSAccessKey(field string) string {
 	field = UniqueIDRegex.ReplaceAllStringFunc(field, func(s string) string {
 		return partialMaskString(s, 4, 4) //nolint:gomnd
 	})
-
-	field = SensitiveKeyRegex.ReplaceAllStringFunc(field, func(s string) string {
-		return partialMaskString(s, 4, 4) //nolint:gomnd
-	})
-
 	return field
 }
 
@@ -44,6 +39,5 @@ func MaskAWSSensitiveValues(field string) string {
 	field = SensitiveKeyRegex.ReplaceAllStringFunc(field, func(s string) string {
 		return partialMaskString(s, 4, 4) //nolint:gomnd
 	})
-
 	return field
 }

--- a/logging/aws.go
+++ b/logging/aws.go
@@ -26,10 +26,20 @@ var UniqueIDRegex = regexp.MustCompile(`(A3T[A-Z0-9]` +
 
 var SensitiveKeyRegex = regexp.MustCompile(`\d[A-Za-z0-9/+=]{16,}`)
 
-func MaskSensitiveValues(field string) string {
+func MaskAWSAccessKey(field string) string {
 	field = UniqueIDRegex.ReplaceAllStringFunc(field, func(s string) string {
 		return partialMaskString(s, 4, 4) //nolint:gomnd
 	})
+
+	field = SensitiveKeyRegex.ReplaceAllStringFunc(field, func(s string) string {
+		return partialMaskString(s, 4, 4) //nolint:gomnd
+	})
+
+	return field
+}
+
+func MaskAWSSensitiveValues(field string) string {
+	field = MaskAWSAccessKey(field)
 
 	field = SensitiveKeyRegex.ReplaceAllStringFunc(field, func(s string) string {
 		return partialMaskString(s, 4, 4) //nolint:gomnd

--- a/logging/aws.go
+++ b/logging/aws.go
@@ -24,9 +24,16 @@ var UniqueIDRegex = regexp.MustCompile(`(A3T[A-Z0-9]` +
 	`|ASIA` + // STS temporary access key
 	`)[A-Z0-9]{16,}`)
 
-func MaskAWSAccessKey(field string) string {
+var SensitiveKeyRegex = regexp.MustCompile(`\d[A-Za-z0-9/+=]{16,}`)
+
+func MaskSensitiveValues(field string) string {
 	field = UniqueIDRegex.ReplaceAllStringFunc(field, func(s string) string {
 		return partialMaskString(s, 4, 4) //nolint:gomnd
 	})
+
+	field = SensitiveKeyRegex.ReplaceAllStringFunc(field, func(s string) string {
+		return partialMaskString(s, 4, 4) //nolint:gomnd
+	})
+
 	return field
 }

--- a/logging/aws.go
+++ b/logging/aws.go
@@ -24,7 +24,7 @@ var UniqueIDRegex = regexp.MustCompile(`(A3T[A-Z0-9]` +
 	`|ASIA` + // STS temporary access key
 	`)[A-Z0-9]{16,}`)
 
-var SensitiveKeyRegex = regexp.MustCompile(`\d[A-Za-z0-9/+=]{16,}`)
+var SensitiveKeyRegex = regexp.MustCompile(`[A-Za-z0-9/+=]{16,}`)
 
 func MaskAWSAccessKey(field string) string {
 	field = UniqueIDRegex.ReplaceAllStringFunc(field, func(s string) string {

--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -1,0 +1,66 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestMaskAWSSensitiveValues(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    string
+		expected string
+	}
+
+	tests := map[string]testCase{
+		"mask_simple": {
+			input:    "4skd4lTSLVBMG/asedterGLKSNMSAlsxiLGfjt=ssD",
+			expected: "4skd**********************************=ssD",
+		},
+		"mask_complex_json": {
+			input: `
+{
+	"AWSSecretKey": "4skd4lTSLVBMG/asedterGLKSNMSAlsxiLGfjt=ssD",
+	"BucketName": "test-bucket",
+	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
+}
+`,
+			expected: `
+{
+	"AWSSecretKey": "4skd**********************************=ssD",
+	"BucketName": "test-bucket",
+	"AWSKeyId": "AIDA*************MPLE",
+}
+`,
+		},
+		"no_mask": {
+			input:    "<BucketName>test-bucket</BucketName>",
+			expected: "<BucketName>test-bucket</BucketName>",
+		},
+		"mask_xml": {
+			input: `
+<AWSSecretKey>4skd4lTSLVBMG/asedterGLKSNMSAlsxiLGfjt=ssD</AWSSecretKey>
+<BucketName>test-bucket</BucketName>
+<AWSKeyId>AIDACKCEVSQ6C2EXAMPLE</AWSKeyId>
+`,
+			expected: `
+<AWSSecretKey>4skd**********************************=ssD</AWSSecretKey>
+<BucketName>test-bucket</BucketName>
+<AWSKeyId>AIDA*************MPLE</AWSKeyId>
+`,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := MaskAWSSensitiveValues(test.input)
+
+			if got != test.expected {
+				t.Errorf("unexpected diff +wanted: %s, -got: %s", test.expected, got)
+			}
+		})
+	}
+}

--- a/logging/http.go
+++ b/logging/http.go
@@ -161,7 +161,7 @@ func authorizationHeaderAttribute(v string) (attribute.KeyValue, bool) {
 				builder.WriteString(", ")
 			}
 		}
-		return key.String(fmt.Sprintf("%s %s", scheme, MaskSensitiveValues(builder.String()))), true
+		return key.String(fmt.Sprintf("%s %s", scheme, MaskAWSSensitiveValues(builder.String()))), true
 	} else {
 		return key.String(fmt.Sprintf("%s %s", scheme, strings.Repeat("*", len(params)))), true
 	}
@@ -229,7 +229,7 @@ func ReadTruncatedBody(reader *textproto.Reader, len int) (string, error) {
 	}
 
 	body := builder.String()
-	body = MaskSensitiveValues(body)
+	body = MaskAWSSensitiveValues(body)
 
 	return body, nil
 }

--- a/logging/http.go
+++ b/logging/http.go
@@ -161,7 +161,7 @@ func authorizationHeaderAttribute(v string) (attribute.KeyValue, bool) {
 				builder.WriteString(", ")
 			}
 		}
-		return key.String(fmt.Sprintf("%s %s", scheme, MaskAWSAccessKey(builder.String()))), true
+		return key.String(fmt.Sprintf("%s %s", scheme, MaskSensitiveValues(builder.String()))), true
 	} else {
 		return key.String(fmt.Sprintf("%s %s", scheme, strings.Repeat("*", len(params)))), true
 	}
@@ -229,7 +229,7 @@ func ReadTruncatedBody(reader *textproto.Reader, len int) (string, error) {
 	}
 
 	body := builder.String()
-	body = MaskAWSAccessKey(body)
+	body = MaskSensitiveValues(body)
 
 	return body, nil
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: [#32164](https://github.com/hashicorp/terraform-provider-aws/issues/32164)

Sensitive values can be logged when the `TF_LOG=TRACE`. To avoid leaking secrets of any kind, logging should mask any pattern that appears to be a secret.