### PR TITLE
Add `awsbase.ErrCodeEquals`, AWS SDK for Go v2 variant of helper in `v2/awsv1shim/tfawserr`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,9 +4,9 @@
 package awsbase
 
 import (
-	"errors"
-
+	smithy "github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/config"
+	"github.com/hashicorp/aws-sdk-go-base/v2/internal/errs"
 )
 
 // CannotAssumeRoleError occurs when AssumeRole cannot complete.
@@ -14,8 +14,7 @@ type CannotAssumeRoleError = config.CannotAssumeRoleError
 
 // IsCannotAssumeRoleError returns true if the error contains the CannotAssumeRoleError type.
 func IsCannotAssumeRoleError(err error) bool {
-	var e CannotAssumeRoleError
-	return errors.As(err, &e)
+	return errs.IsA[CannotAssumeRoleError](err)
 }
 
 // NoValidCredentialSourcesError occurs when all credential lookup methods have been exhausted without results.
@@ -23,6 +22,21 @@ type NoValidCredentialSourcesError = config.NoValidCredentialSourcesError
 
 // IsNoValidCredentialSourcesError returns true if the error contains the NoValidCredentialSourcesError type.
 func IsNoValidCredentialSourcesError(err error) bool {
-	var e NoValidCredentialSourcesError
-	return errors.As(err, &e)
+	return errs.IsA[NoValidCredentialSourcesError](err)
+}
+
+// AWS SDK for Go v2 variants of helpers in v2/awsv1shim/tfawserr.
+
+// ErrCodeEquals returns true if the error matches all these conditions:
+//   - err is of type smithy.APIError
+//   - Error.Code() equals one of the passed codes
+func ErrCodeEquals(err error, codes ...string) bool {
+	if apiErr, ok := errs.As[smithy.APIError](err); ok {
+		for _, code := range codes {
+			if apiErr.ErrorCode() == code {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,6 @@
 package awsbase
 
 import (
-	smithy "github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/config"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/errs"
 )
@@ -23,20 +22,4 @@ type NoValidCredentialSourcesError = config.NoValidCredentialSourcesError
 // IsNoValidCredentialSourcesError returns true if the error contains the NoValidCredentialSourcesError type.
 func IsNoValidCredentialSourcesError(err error) bool {
 	return errs.IsA[NoValidCredentialSourcesError](err)
-}
-
-// AWS SDK for Go v2 variants of helpers in v2/awsv1shim/tfawserr.
-
-// ErrCodeEquals returns true if the error matches all these conditions:
-//   - err is of type smithy.APIError
-//   - Error.Code() equals one of the passed codes
-func ErrCodeEquals(err error, codes ...string) bool {
-	if apiErr, ok := errs.As[smithy.APIError](err); ok {
-		for _, code := range codes {
-			if apiErr.ErrorCode() == code {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package awsbase
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+func TestIsCannotAssumeRoleError(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+		},
+		{
+			Name: "Top-level NoValidCredentialSourcesError",
+			Err:  NoValidCredentialSourcesError{},
+		},
+		{
+			Name:     "Top-level CannotAssumeRoleError",
+			Err:      CannotAssumeRoleError{},
+			Expected: true,
+		},
+		{
+			Name:     "Nested CannotAssumeRoleError",
+			Err:      fmt.Errorf("test: %w", CannotAssumeRoleError{}),
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsCannotAssumeRoleError(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestIsNoValidCredentialSourcesError(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+		},
+		{
+			Name: "Top-level CannotAssumeRoleError",
+			Err:  CannotAssumeRoleError{},
+		},
+		{
+			Name:     "Top-level NoValidCredentialSourcesError",
+			Err:      NoValidCredentialSourcesError{},
+			Expected: true,
+		},
+		{
+			Name:     "Nested NoValidCredentialSourcesError",
+			Err:      fmt.Errorf("test: %w", NoValidCredentialSourcesError{}),
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := IsNoValidCredentialSourcesError(testCase.Err)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestErrCodeEquals(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Codes    []string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+		},
+		{
+			Name: "Top-level CannotAssumeRoleError",
+			Err:  CannotAssumeRoleError{},
+		},
+		{
+			Name:     "Top-level smithy.GenericAPIError matching first code",
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Top-level smithy.GenericAPIError matching last code",
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name: "Top-level smithy.GenericAPIError no code",
+			Err:  &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+		},
+		{
+			Name:  "Top-level smithy.GenericAPIError non-matching codes",
+			Err:   &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+		{
+			Name:     "Wrapped smithy.GenericAPIError matching first code",
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped smithy.GenericAPIError matching last code",
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name:  "Wrapped smithy.GenericAPIError non-matching codes",
+			Err:   fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+		{
+			Name:     "Top-level sts ExpiredTokenException matching first code",
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Top-level sts ExpiredTokenException matching last code",
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped sts ExpiredTokenException matching first code",
+			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped sts ExpiredTokenException matching last code",
+			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,10 +6,6 @@ package awsbase
 import (
 	"fmt"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/sts/types"
-	smithy "github.com/aws/smithy-go"
 )
 
 func TestIsCannotAssumeRoleError(t *testing.T) {
@@ -80,97 +76,6 @@ func TestIsNoValidCredentialSourcesError(t *testing.T) {
 
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsNoValidCredentialSourcesError(testCase.Err)
-
-			if got != testCase.Expected {
-				t.Errorf("got %t, expected %t", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-func TestErrCodeEquals(t *testing.T) {
-	testCases := []struct {
-		Name     string
-		Err      error
-		Codes    []string
-		Expected bool
-	}{
-		{
-			Name: "nil error",
-		},
-		{
-			Name: "Top-level CannotAssumeRoleError",
-			Err:  CannotAssumeRoleError{},
-		},
-		{
-			Name:     "Top-level smithy.GenericAPIError matching first code",
-			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
-			Codes:    []string{"TestCode"},
-			Expected: true,
-		},
-		{
-			Name:     "Top-level smithy.GenericAPIError matching last code",
-			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
-			Codes:    []string{"NotMatching", "TestCode"},
-			Expected: true,
-		},
-		{
-			Name: "Top-level smithy.GenericAPIError no code",
-			Err:  &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
-		},
-		{
-			Name:  "Top-level smithy.GenericAPIError non-matching codes",
-			Err:   &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
-			Codes: []string{"NotMatching", "AlsoNotMatching"},
-		},
-		{
-			Name:     "Wrapped smithy.GenericAPIError matching first code",
-			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
-			Codes:    []string{"TestCode"},
-			Expected: true,
-		},
-		{
-			Name:     "Wrapped smithy.GenericAPIError matching last code",
-			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
-			Codes:    []string{"NotMatching", "TestCode"},
-			Expected: true,
-		},
-		{
-			Name:  "Wrapped smithy.GenericAPIError non-matching codes",
-			Err:   fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
-			Codes: []string{"NotMatching", "AlsoNotMatching"},
-		},
-		{
-			Name:     "Top-level sts ExpiredTokenException matching first code",
-			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
-			Codes:    []string{"TestCode"},
-			Expected: true,
-		},
-		{
-			Name:     "Top-level sts ExpiredTokenException matching last code",
-			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
-			Codes:    []string{"NotMatching", "TestCode"},
-			Expected: true,
-		},
-		{
-			Name:     "Wrapped sts ExpiredTokenException matching first code",
-			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
-			Codes:    []string{"TestCode"},
-			Expected: true,
-		},
-		{
-			Name:     "Wrapped sts ExpiredTokenException matching last code",
-			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
-			Codes:    []string{"NotMatching", "TestCode"},
-			Expected: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.Name, func(t *testing.T) {
-			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
 
 			if got != testCase.Expected {
 				t.Errorf("got %t, expected %t", got, testCase.Expected)

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package errs
+
+import (
+	"errors"
+)
+
+// IsA indicates whether an error matches an error type.
+func IsA[T error](err error) bool {
+	_, ok := As[T](err)
+	return ok
+}
+
+// As is equivalent to errors.As(), but returns the value in-line.
+func As[T error](err error) (T, bool) {
+	var as T
+	ok := errors.As(err, &as)
+	return as, ok
+}

--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfawserr
+
+import (
+	smithy "github.com/aws/smithy-go"
+	"github.com/hashicorp/aws-sdk-go-base/v2/internal/errs"
+)
+
+// ErrCodeEquals returns true if the error matches all these conditions:
+//   - err is of type smithy.APIError
+//   - Error.Code() equals one of the passed codes
+func ErrCodeEquals(err error, codes ...string) bool {
+	if apiErr, ok := errs.As[smithy.APIError](err); ok {
+		for _, code := range codes {
+			if apiErr.ErrorCode() == code {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
-	"github.com/aws/aws-sdk-go/aws"
 	smithy "github.com/aws/smithy-go"
 )
 

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfawserr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/aws/aws-sdk-go/aws"
+	smithy "github.com/aws/smithy-go"
+	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+)
+
+func TestErrCodeEquals(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Err      error
+		Codes    []string
+		Expected bool
+	}{
+		{
+			Name: "nil error",
+		},
+		{
+			Name: "Top-level CannotAssumeRoleError",
+			Err:  awsbase.CannotAssumeRoleError{},
+		},
+		{
+			Name:     "Top-level smithy.GenericAPIError matching first code",
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Top-level smithy.GenericAPIError matching last code",
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name: "Top-level smithy.GenericAPIError no code",
+			Err:  &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+		},
+		{
+			Name:  "Top-level smithy.GenericAPIError non-matching codes",
+			Err:   &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+		{
+			Name:     "Wrapped smithy.GenericAPIError matching first code",
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped smithy.GenericAPIError matching last code",
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name:  "Wrapped smithy.GenericAPIError non-matching codes",
+			Err:   fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Codes: []string{"NotMatching", "AlsoNotMatching"},
+		},
+		{
+			Name:     "Top-level sts ExpiredTokenException matching first code",
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Top-level sts ExpiredTokenException matching last code",
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped sts ExpiredTokenException matching first code",
+			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
+			Codes:    []string{"TestCode"},
+			Expected: true,
+		},
+		{
+			Name:     "Wrapped sts ExpiredTokenException matching last code",
+			Err:      fmt.Errorf("test: %w", &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")}),
+			Codes:    []string{"NotMatching", "TestCode"},
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.Name, func(t *testing.T) {
+			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds an AWS SDK for Go v2 variant of the `ErrCodeEquals` helper in `v2/awsv1shim/tfawserr`.
Not all services in the AWS SDK for Go v2 uses [strongly-typed, modeled errors](https://aws.github.io/aws-sdk-go-v2/docs/handling-errors/#api-error-responses) (EC2 is top of mind).
To support testing the returned API error code for these servies, add a variant of the `ErrCodeEquals` helper function defined in `v2/awsv1shim/tfawserr` that uses the [`smithy.APIError`](https://pkg.go.dev/github.com/aws/smithy-go#APIError) interface.

```console
% go test ./...
ok  	github.com/hashicorp/aws-sdk-go-base/v2	5.656s
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/config	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/constants	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints	0.313s
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/errs	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/expand	0.629s
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/slices	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/test	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/logging	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/mockdata	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/servicemocks	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2/useragent	0.690s
```
