### PR TITLE
Add `tfawserr.ErrMessageContains`, AWS SDK for Go v2 variant of helper in `v2/awsv1shim/tfawserr`

### DIFF
--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -4,13 +4,15 @@
 package tfawserr
 
 import (
+	"strings"
+
 	smithy "github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/errs"
 )
 
 // ErrCodeEquals returns true if the error matches all these conditions:
 //   - err is of type smithy.APIError
-//   - Error.Code() equals one of the passed codes
+//   - APIError.ErrorCode() equals one of the passed codes
 func ErrCodeEquals(err error, codes ...string) bool {
 	if apiErr, ok := errs.As[smithy.APIError](err); ok {
 		for _, code := range codes {
@@ -18,6 +20,17 @@ func ErrCodeEquals(err error, codes ...string) bool {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// ErrMessageContains returns true if the error matches all these conditions:
+//   - err is of type smithy.APIError
+//   - APIError.ErrorCode() equals code
+//   - APIError.ErrorMessage() contains message
+func ErrMessageContains(err error, code string, message string) bool {
+	if apiErr, ok := errs.As[smithy.APIError](err); ok {
+		return apiErr.ErrorCode() == code && strings.Contains(apiErr.ErrorMessage(), message)
 	}
 	return false
 }

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -91,3 +91,136 @@ func TestErrCodeEquals(t *testing.T) {
 		})
 	}
 }
+
+func TestErrMessageContains(t *testing.T) {
+	testCases := map[string]struct {
+		Err      error
+		Code     string
+		Message  string
+		Expected bool
+	}{
+		"nil error": {
+			Err:      nil,
+			Expected: false,
+		},
+		"nil error code": {
+			Err:      nil,
+			Code:     "test",
+			Expected: false,
+		},
+		"nil error message": {
+			Err:     nil,
+			Message: "test",
+		},
+		"nil error code and message": {
+			Err:     nil,
+			Code:    "test",
+			Message: "test",
+		},
+		"other error": {
+			Err:      fmt.Errorf("other error"),
+			Expected: false,
+		},
+		"other error code and message": {
+			Err:     fmt.Errorf("other error"),
+			Code:    "test",
+			Message: "test",
+		},
+		"Top-level smithy.GenericAPIError no code": {
+			Err: &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+		},
+		"Top-level smithy.GenericAPIError matching code and no message": {
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Code:     "TestCode",
+			Expected: true,
+		},
+		"Top-level smithy.GenericAPIError matching code and matching message exact": {
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		"Top-level smithy.GenericAPIError non-matching code and matching message exact": {
+			Err:     &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Code:    "NotMatching",
+			Message: "TestMessage",
+		},
+		"Top-level smithy.GenericAPIError matching code and matching message contains": {
+			Err:      &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Code:     "TestCode",
+			Message:  "estMess",
+			Expected: true,
+		},
+		"Top-level smithy.GenericAPIError matching code and non-matching message": {
+			Err:     &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"},
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		"Wrapped smithy.GenericAPIError matching code and no message": {
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Code:     "TestCode",
+			Expected: true,
+		},
+		"Wrapped smithy.GenericAPIError matching code and matching message exact": {
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		"Wrapped smithy.GenericAPIError non-matching code and matching message exact": {
+			Err:     fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Code:    "NotMatching",
+			Message: "TestMessage",
+		},
+		"Wrapped smithy.GenericAPIError matching code and matching message contains": {
+			Err:      fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Code:     "TestCode",
+			Message:  "estMess",
+			Expected: true,
+		},
+		"Wrapped smithy.GenericAPIError matching code and non-matching message": {
+			Err:     fmt.Errorf("test: %w", &smithy.GenericAPIError{Code: "TestCode", Message: "TestMessage"}),
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+		"Top-level sts ExpiredTokenException matching code and no message": {
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Code:     "TestCode",
+			Expected: true,
+		},
+		"Top-level sts ExpiredTokenException matching code and matching message exact": {
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Code:     "TestCode",
+			Message:  "TestMessage",
+			Expected: true,
+		},
+		"Top-level sts ExpiredTokenException non-matching code and matching message exact": {
+			Err:     &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Code:    "NotMatching",
+			Message: "TestMessage",
+		},
+		"Top-level sts ExpiredTokenException matching code and matching message contains": {
+			Err:      &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Code:     "TestCode",
+			Message:  "estMess",
+			Expected: true,
+		},
+		"Top-level sts ExpiredTokenException matching code and non-matching message": {
+			Err:     &types.ExpiredTokenException{ErrorCodeOverride: aws.String("TestCode"), Message: aws.String("TestMessage")},
+			Code:    "TestCode",
+			Message: "NotMatching",
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(name, func(t *testing.T) {
+			got := ErrMessageContains(testCase.Err, testCase.Code, testCase.Message)
+
+			if got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds an AWS SDK for Go v2 variant of the `ErrMessageContains` helper in `v2/awsv1shim/tfawserr`.

Relates https://github.com/hashicorp/aws-sdk-go-base/pull/524.

```console
% go test ./...
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/config	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/constants	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/errs	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/slices	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/test	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/mockdata	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/servicemocks	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2	6.322s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints	0.901s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/expand	0.617s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/logging	0.562s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/tfawserr	0.353s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/useragent	0.801s
```
