### PR TITLE
ci: group aws-sdk-go dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     groups:
       aws-sdk-go:
         patterns:
-          - "github.com/aws/aws-sdk-go"
           - "github.com/aws/aws-sdk-go-v2/*"
     ignore:
       - dependency-name: "golang.org/x/tools"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      aws-sdk-go:
+        patterns:
+          - "github.com/aws/aws-sdk-go"
+          - "github.com/aws/aws-sdk-go-v2/*"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"


### PR DESCRIPTION
Groups AWS SDK Go v1 and v2 dependabot updates into a single PR.