### PR TITLE
Ignores all `aws-sdk-go-v2` modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
     directory: "/v2/awsv1shim"
     ignore:
       - dependency-name: "github.com/aws/aws-sdk-go-v2"
+      - dependency-name: "github.com/aws/aws-sdk-go-v2/*"
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"
     schedule:


### PR DESCRIPTION
Updates Dependabot `ignores` parameter for `awsv1shim` to include all `aws-sdk-go-v2` modules