### PR TITLE
feat: enable opt-in legacy authentication flow

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -997,6 +997,61 @@ aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
 `,
 		},
+		{
+			Config: &Config{
+				Profile: "SharedCredentialsProfile",
+				Region:  "us-east-1",
+			},
+			Description: "environment AWS_ACCESS_KEY_ID does not override config Profile",
+			EnvironmentVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
+				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
+			},
+			ExpectedCredentialsValue: aws.Credentials{
+				AccessKeyID:     "ProfileSharedCredentialsAccessKey",
+				SecretAccessKey: "ProfileSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+			ExpectedRegion: "us-east-1",
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+			},
+			SharedCredentialsFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+
+[SharedCredentialsProfile]
+aws_access_key_id = ProfileSharedCredentialsAccessKey
+aws_secret_access_key = ProfileSharedCredentialsSecretKey
+`,
+		},
+		{
+			Config: &Config{
+				Profile:           "SharedCredentialsProfile",
+				Region:            "us-east-1",
+				UseLegacyWorkflow: true,
+			},
+			Description: "environment AWS_ACCESS_KEY_ID overrides config Profile in legacy workflow",
+			EnvironmentVariables: map[string]string{
+				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
+				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
+			},
+			ExpectedCredentialsValue: mockdata.MockEnvCredentials,
+			ExpectedRegion:           "us-east-1",
+			MockStsEndpoints: []*servicemocks.MockEndpoint{
+				servicemocks.MockStsGetCallerIdentityValidEndpoint,
+			},
+			SharedCredentialsFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+
+[SharedCredentialsProfile]
+aws_access_key_id = ProfileSharedCredentialsAccessKey
+aws_secret_access_key = ProfileSharedCredentialsSecretKey
+`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/credentials.go
+++ b/credentials.go
@@ -46,13 +46,15 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 
 	if c.Profile != "" && os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
 		if c.UseLegacyWorkflow {
-			logger.Warn(ctx, `A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
-				`The legacy workflow is enabled, so the Profile will be ignored in favor of the environment variable credentials. `+
-				`This behavior may be removed in the future.`)
+			diags.AddWarning("Configuration conflict overridden",
+				`A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
+					`The legacy workflow is enabled, so the Profile will be ignored in favor of the environment variable credentials. `+
+					`This behavior may be removed in the future.`)
 			c.Profile = ""
 		} else {
-			logger.Warn(ctx, `A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
-				"The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.")
+			diags.AddWarning("Configuration conflict detected",
+				`A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
+					`The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.`)
 		}
 	}
 

--- a/credentials.go
+++ b/credentials.go
@@ -45,8 +45,15 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 	}
 
 	if c.Profile != "" && os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
-		logger.Warn(ctx, `A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
-			"The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.")
+		if c.UseLegacyWorkflow {
+			logger.Warn(ctx, `A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
+				`The legacy workflow is enabled, so the Profile will be ignored in favor of the environment variable credentials. `+
+				`This behavior may be removed in the future.`)
+			c.Profile = ""
+		} else {
+			logger.Warn(ctx, `A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
+				"The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.")
+		}
 	}
 
 	// The default AWS SDK authentication flow silently ignores invalid Profiles. Pre-validate that the Profile exists

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Token                          string
 	UseDualStackEndpoint           bool
 	UseFIPSEndpoint                bool
+	UseLegacyWorkflow              bool
 	UserAgent                      UserAgentProducts
 }
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->



Adds an opt-in "legacy" workflow to support the Terraform core S3 backend upgrade which will span multiple minor versions. 

```console
$ go test -count=1 ./...
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig      [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/config [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/constants      [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/errs   [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/slices [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/test   [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/mockdata        [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/servicemocks    [no test files]
ok      github.com/hashicorp/aws-sdk-go-base/v2 5.441s
ok      github.com/hashicorp/aws-sdk-go-base/v2/diag    0.296s
ok      github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints      0.188s
ok      github.com/hashicorp/aws-sdk-go-base/v2/internal/expand 0.237s
ok      github.com/hashicorp/aws-sdk-go-base/v2/logging 0.225s
ok      github.com/hashicorp/aws-sdk-go-base/v2/tfawserr        0.289s
ok      github.com/hashicorp/aws-sdk-go-base/v2/useragent       0.336s
```
