### PR TITLE
Add Support for logging with `hc-log`

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -40,7 +40,7 @@ func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, 
 	var diags diag.Diagnostics
 	ctx = configCommonLogging(ctx)
 
-	baseCtx, logger := logging.New(ctx, loggerName)
+	baseCtx, logger := logging.NewTfLogger(ctx, loggerName)
 	baseCtx = logging.RegisterLogger(baseCtx, logger)
 
 	logger.Trace(baseCtx, "Resolving AWS configuration")
@@ -210,7 +210,7 @@ func (r *networkErrorShortcutter) RetryDelay(attempt int, err error) (time.Durat
 func GetAwsAccountIDAndPartition(ctx context.Context, awsConfig aws.Config, c *Config) (string, string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	ctx = configCommonLogging(ctx)
-	ctx, logger := logging.New(ctx, loggerName)
+	ctx, logger := logging.NewTfLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	if !c.SkipCredsValidation {

--- a/aws_config.go
+++ b/aws_config.go
@@ -38,9 +38,12 @@ func configCommonLogging(ctx context.Context) context.Context {
 
 func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	ctx, tflogger := logging.NewTfLogger(ctx)
+	ctx = logging.RegisterLogger(ctx, tflogger)
 	ctx = configCommonLogging(ctx)
 
-	baseCtx, logger := logging.NewTfLogger(ctx, loggerName)
+	baseCtx, logger := tflogger.SubLogger(ctx, loggerName)
 	baseCtx = logging.RegisterLogger(baseCtx, logger)
 
 	logger.Trace(baseCtx, "Resolving AWS configuration")
@@ -210,7 +213,8 @@ func (r *networkErrorShortcutter) RetryDelay(attempt int, err error) (time.Durat
 func GetAwsAccountIDAndPartition(ctx context.Context, awsConfig aws.Config, c *Config) (string, string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	ctx = configCommonLogging(ctx)
-	ctx, logger := logging.NewTfLogger(ctx, loggerName)
+	ctx, tflogger := logging.NewTfLogger(ctx)
+	ctx, logger := tflogger.SubLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	if !c.SkipCredsValidation {

--- a/aws_config.go
+++ b/aws_config.go
@@ -39,11 +39,14 @@ func configCommonLogging(ctx context.Context) context.Context {
 func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	ctx, tflogger := logging.NewTfLogger(ctx)
-	ctx = logging.RegisterLogger(ctx, tflogger)
+	var logger logging.Logger = logging.NullLogger{}
+	if c.Logger != nil {
+		logger = c.Logger
+	}
+	ctx = logging.RegisterLogger(ctx, logger)
 	ctx = configCommonLogging(ctx)
 
-	baseCtx, logger := tflogger.SubLogger(ctx, loggerName)
+	baseCtx, logger := logger.SubLogger(ctx, loggerName)
 	baseCtx = logging.RegisterLogger(baseCtx, logger)
 
 	logger.Trace(baseCtx, "Resolving AWS configuration")
@@ -212,9 +215,13 @@ func (r *networkErrorShortcutter) RetryDelay(attempt int, err error) (time.Durat
 
 func GetAwsAccountIDAndPartition(ctx context.Context, awsConfig aws.Config, c *Config) (string, string, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	var logger logging.Logger = logging.NullLogger{}
+	if c.Logger != nil {
+		logger = c.Logger
+	}
 	ctx = configCommonLogging(ctx)
-	ctx, tflogger := logging.NewTfLogger(ctx)
-	ctx, logger := tflogger.SubLogger(ctx, loggerName)
+	ctx, logger = logger.SubLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	if !c.SkipCredsValidation {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.21.1
 	github.com/aws/smithy-go v1.14.0
 	github.com/google/go-cmp v0.5.9
+	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -27,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.15.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/expand"
+	"github.com/hashicorp/aws-sdk-go-base/v2/logging"
 )
 
 type Config struct {
@@ -33,6 +34,7 @@ type Config struct {
 	HTTPProxy                      string
 	IamEndpoint                    string
 	Insecure                       bool
+	Logger                         logging.Logger
 	MaxRetries                     int
 	Profile                        string
 	Region                         string

--- a/logging/context.go
+++ b/logging/context.go
@@ -16,5 +16,9 @@ func RegisterLogger(ctx context.Context, logger Logger) context.Context {
 }
 
 func RetrieveLogger(ctx context.Context) Logger {
-	return ctx.Value(loggerKey).(Logger)
+	logger, ok := ctx.Value(loggerKey).(Logger)
+	if !ok {
+		return NullLogger{}
+	}
+	return logger
 }

--- a/logging/context.go
+++ b/logging/context.go
@@ -11,14 +11,10 @@ type loggerKeyT string
 
 const loggerKey loggerKeyT = "logger-key"
 
-func RegisterLogger(ctx context.Context, logger TfLogger) context.Context {
+func RegisterLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
-func RetrieveLogger(ctx context.Context) TfLogger {
-	logger, ok := ctx.Value(loggerKey).(TfLogger)
-	if !ok {
-		return TfLogger("")
-	}
-	return logger
+func RetrieveLogger(ctx context.Context) Logger {
+	return ctx.Value(loggerKey).(Logger)
 }

--- a/logging/hc_logger.go
+++ b/logging/hc_logger.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+type HcLogger struct{}
+
+var _ Logger = HcLogger{}
+
+func NewHcLogger(ctx context.Context, logger hclog.Logger) (context.Context, HcLogger) {
+	ctx = hclog.WithContext(ctx, logger)
+
+	return ctx, HcLogger{}
+}
+
+func (l HcLogger) SubLogger(ctx context.Context, name string) (context.Context, Logger) {
+	logger := hclog.FromContext(ctx)
+	logger = logger.Named(name)
+	ctx = hclog.WithContext(ctx, logger)
+
+	return ctx, HcLogger{}
+}
+
+func (l HcLogger) Warn(ctx context.Context, msg string, fields ...map[string]any) {
+	logger := hclog.FromContext(ctx)
+	logger.Warn(msg, flattenFields(fields...)...)
+}
+
+func (l HcLogger) Info(ctx context.Context, msg string, fields ...map[string]any) {
+	logger := hclog.FromContext(ctx)
+	logger.Info(msg, flattenFields(fields...)...)
+}
+
+func (l HcLogger) Debug(ctx context.Context, msg string, fields ...map[string]any) {
+	logger := hclog.FromContext(ctx)
+	logger.Debug(msg, flattenFields(fields...)...)
+}
+
+func (l HcLogger) Trace(ctx context.Context, msg string, fields ...map[string]any) {
+	logger := hclog.FromContext(ctx)
+	logger.Trace(msg, flattenFields(fields...)...)
+}
+
+// TODO: how to handle duplicates
+func flattenFields(fields ...map[string]any) []any {
+	var totalLen int
+	for _, m := range fields {
+		totalLen = len(m)
+	}
+	f := make([]any, 0, totalLen*2) //nolint:gomnd
+
+	for _, m := range fields {
+		for k, v := range m {
+			f = append(f, k, v)
+		}
+	}
+	return f
+}
+
+func (l HcLogger) SetField(ctx context.Context, key string, value any) context.Context {
+	logger := hclog.FromContext(ctx)
+	logger = logger.With(key, value)
+	ctx = hclog.WithContext(ctx, logger)
+	return ctx
+}

--- a/logging/hc_logger_test.go
+++ b/logging/hc_logger_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+const hclogRootName = "hc-log-test"
+
+func TestHcLoggerWarn(t *testing.T) {
+	testLoggerWarn(t, hclogRootName, hcLoggerFactory)
+}
+
+func TestHcLoggerSetField(t *testing.T) {
+	testLoggerSetField(t, hclogRootName, hcLoggerFactory)
+}
+
+func hcLoggerFactory(ctx context.Context, name string, output io.Writer) (context.Context, Logger) {
+	hclogger := configureHcLogger(output)
+
+	ctx, rootLogger := NewHcLogger(ctx, hclogger)
+	ctx, logger := rootLogger.SubLogger(ctx, name)
+
+	return ctx, logger
+}
+
+// configureHcLogger configures the default logger with settings suitable for testing:
+//
+//   - Log level set to TRACE
+//   - Written to the io.Writer passed in, such as a bytes.Buffer
+//   - Log entries are in JSON format, and can be decoded using multilineJSONDecode
+//   - Caller information is not included
+//   - Timestamp is not included
+func configureHcLogger(output io.Writer) hclog.Logger {
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:              hclogRootName,
+		Level:             hclog.Trace,
+		Output:            output,
+		IndependentLevels: true,
+		JSONFormat:        true,
+		IncludeLocation:   false,
+		DisableTime:       true,
+	})
+
+	return logger
+}

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -5,55 +5,13 @@ package logging
 
 import (
 	"context"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func New(ctx context.Context, name string) (context.Context, TfLogger) {
-	ctx = tflog.NewSubsystem(ctx, name, tflog.WithRootFields())
-	logger := TfLogger(name)
+type Logger interface {
+	Warn(ctx context.Context, msg string, fields ...map[string]any)
+	Info(ctx context.Context, msg string, fields ...map[string]any)
+	Debug(ctx context.Context, msg string, fields ...map[string]any)
+	Trace(ctx context.Context, msg string, fields ...map[string]any)
 
-	return ctx, logger
-}
-
-type TfLogger string
-
-func (l TfLogger) Warn(ctx context.Context, msg string, fields ...map[string]any) {
-	if l == "" {
-		tflog.Warn(ctx, msg, fields...)
-	} else {
-		tflog.SubsystemWarn(ctx, string(l), msg, fields...)
-	}
-}
-
-func (l TfLogger) Info(ctx context.Context, msg string, fields ...map[string]any) {
-	if l == "" {
-		tflog.Info(ctx, msg, fields...)
-	} else {
-		tflog.SubsystemInfo(ctx, string(l), msg, fields...)
-	}
-}
-
-func (l TfLogger) Debug(ctx context.Context, msg string, fields ...map[string]any) {
-	if l == "" {
-		tflog.Debug(ctx, msg, fields...)
-	} else {
-		tflog.SubsystemDebug(ctx, string(l), msg, fields...)
-	}
-}
-
-func (l TfLogger) Trace(ctx context.Context, msg string, fields ...map[string]any) {
-	if l == "" {
-		tflog.Trace(ctx, msg, fields...)
-	} else {
-		tflog.SubsystemTrace(ctx, string(l), msg, fields...)
-	}
-}
-
-func (l TfLogger) SetField(ctx context.Context, key string, value any) context.Context {
-	if l == "" {
-		return tflog.SetField(ctx, key, value)
-	} else {
-		return tflog.SubsystemSetField(ctx, string(l), key, value)
-	}
+	SetField(ctx context.Context, key string, value any) context.Context
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -14,4 +14,6 @@ type Logger interface {
 	Trace(ctx context.Context, msg string, fields ...map[string]any)
 
 	SetField(ctx context.Context, key string, value any) context.Context
+
+	SubLogger(ctx context.Context, name string) (context.Context, Logger)
 }

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+)
+
+func testLoggerWarn(t *testing.T, rootName string, factory func(ctx context.Context, name string, output io.Writer) (context.Context, Logger)) {
+	t.Helper()
+
+	loggerName := "test"
+	expectedModule := rootName + "." + loggerName
+
+	var buf bytes.Buffer
+	ctx := context.Background()
+	ctx, logger := factory(ctx, loggerName, &buf)
+
+	logger.Warn(ctx, "message", map[string]any{
+		"one": int(1),
+		"two": "two",
+	})
+
+	lines, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("decoding log lines: %s", err)
+	}
+
+	expected := []map[string]any{
+		{
+			"@level":   "warn",
+			"@module":  expectedModule,
+			"@message": "message",
+			"one":      float64(1),
+			"two":      "two",
+		},
+	}
+
+	if diff := cmp.Diff(expected, lines); diff != "" {
+		t.Errorf("unexpected logger output difference: %s", diff)
+	}
+}
+
+func testLoggerSetField(t *testing.T, rootName string, factory func(ctx context.Context, name string, output io.Writer) (context.Context, Logger)) {
+	t.Helper()
+
+	loggerName := "test"
+	expectedModule := rootName + "." + loggerName
+
+	var buf bytes.Buffer
+	originalCtx := context.Background()
+	originalCtx, logger := factory(originalCtx, loggerName, &buf)
+
+	newCtx := logger.SetField(originalCtx, "key", "value")
+
+	logger.Warn(newCtx, "new logger")
+	logger.Warn(newCtx, "new logger", map[string]any{
+		"key": "other value",
+	})
+	logger.Warn(originalCtx, "original logger")
+
+	lines, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("ctxWithField: decoding log lines: %s", err)
+	}
+
+	expected := []map[string]any{
+		{
+			"@level":   "warn",
+			"@module":  expectedModule,
+			"@message": "new logger",
+			"key":      "value",
+		},
+		{
+			"@level":   "warn",
+			"@module":  expectedModule,
+			"@message": "new logger",
+			"key":      "other value",
+		},
+		{
+			"@level":   "warn",
+			"@module":  expectedModule,
+			"@message": "original logger",
+		},
+	}
+
+	if diff := cmp.Diff(expected, lines); diff != "" {
+		t.Errorf("unexpected logger output difference: %s", diff)
+	}
+}

--- a/logging/null_logger.go
+++ b/logging/null_logger.go
@@ -1,0 +1,33 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"context"
+)
+
+type NullLogger struct {
+}
+
+var _ Logger = NullLogger{}
+
+func (l NullLogger) SubLogger(ctx context.Context, name string) (context.Context, Logger) {
+	return ctx, l
+}
+
+func (l NullLogger) Warn(ctx context.Context, msg string, fields ...map[string]any) {
+}
+
+func (l NullLogger) Info(ctx context.Context, msg string, fields ...map[string]any) {
+}
+
+func (l NullLogger) Debug(ctx context.Context, msg string, fields ...map[string]any) {
+}
+
+func (l NullLogger) Trace(ctx context.Context, msg string, fields ...map[string]any) {
+}
+
+func (l NullLogger) SetField(ctx context.Context, key string, value any) context.Context {
+	return ctx
+}

--- a/logging/tf_logger.go
+++ b/logging/tf_logger.go
@@ -9,16 +9,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func NewTfLogger(ctx context.Context, name string) (context.Context, TfLogger) {
+type TfLogger string
+
+var _ Logger = TfLogger("")
+
+func NewTfLogger(ctx context.Context) (context.Context, TfLogger) {
+	return ctx, TfLogger("")
+}
+
+func (l TfLogger) SubLogger(ctx context.Context, name string) (context.Context, Logger) {
 	ctx = tflog.NewSubsystem(ctx, name, tflog.WithRootFields())
 	logger := TfLogger(name)
 
 	return ctx, logger
 }
-
-type TfLogger string
-
-var _ Logger = TfLogger("")
 
 func (l TfLogger) Warn(ctx context.Context, msg string, fields ...map[string]any) {
 	if l == "" {

--- a/logging/tf_logger.go
+++ b/logging/tf_logger.go
@@ -1,0 +1,69 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+func NewTfLogger(ctx context.Context, name string) (context.Context, TfLogger) {
+	ctx = tflog.NewSubsystem(ctx, name, tflog.WithRootFields())
+	logger := TfLogger(name)
+
+	return ctx, logger
+}
+
+type TfLogger string
+
+var _ Logger = TfLogger("")
+
+func (l TfLogger) Warn(ctx context.Context, msg string, fields ...map[string]any) {
+	if l == "" {
+		tflog.Warn(ctx, msg, fields...)
+	} else {
+		tflog.SubsystemWarn(ctx, string(l), msg, fields...)
+	}
+}
+
+func (l TfLogger) Info(ctx context.Context, msg string, fields ...map[string]any) {
+	if l == "" {
+		tflog.Info(ctx, msg, fields...)
+	} else {
+		tflog.SubsystemInfo(ctx, string(l), msg, fields...)
+	}
+}
+
+func (l TfLogger) Debug(ctx context.Context, msg string, fields ...map[string]any) {
+	if l == "" {
+		tflog.Debug(ctx, msg, fields...)
+	} else {
+		tflog.SubsystemDebug(ctx, string(l), msg, fields...)
+	}
+}
+
+func (l TfLogger) Trace(ctx context.Context, msg string, fields ...map[string]any) {
+	if l == "" {
+		tflog.Trace(ctx, msg, fields...)
+	} else {
+		tflog.SubsystemTrace(ctx, string(l), msg, fields...)
+	}
+}
+
+func (l TfLogger) SetField(ctx context.Context, key string, value any) context.Context {
+	if l == "" {
+		return tflog.SetField(ctx, key, value)
+	} else {
+		return tflog.SubsystemSetField(ctx, string(l), key, value)
+	}
+}
+
+// func (l TfLogger) MaskAllFieldValuesRegexes(ctx context.Context, expressions ...*regexp.Regexp) context.Context {
+// 	if l == "" {
+// 		return tflog.MaskAllFieldValuesRegexes(ctx, expressions...)
+// 	} else {
+// 		return tflog.SubsystemMaskAllFieldValuesRegexes(ctx, string(l), expressions...)
+// 	}
+// }

--- a/logging/tf_logger_test.go
+++ b/logging/tf_logger_test.go
@@ -4,93 +4,28 @@
 package logging
 
 import (
-	"bytes"
 	"context"
-	"fmt"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-log/tflogtest"
 )
 
+const tflogRootName = "provider"
+
 func TestTfLoggerWarn(t *testing.T) {
-	var buf bytes.Buffer
-	ctx := tflogtest.RootLogger(context.Background(), &buf)
-
-	loggerName := "test"
-	expectedModule := fmt.Sprintf("provider.%s", loggerName)
-	ctx, logger := NewTfLogger(ctx, loggerName)
-
-	logger.Warn(ctx, "message", map[string]any{
-		"one": int(1),
-		"two": "two",
-	})
-
-	lines, err := tflogtest.MultilineJSONDecode(&buf)
-	if err != nil {
-		t.Fatalf("decoding log lines: %s", err)
-	}
-
-	if l := len(lines); l != 1 {
-		t.Fatalf("expected 1 log entry, got %d\n%v", l, lines)
-	}
-
-	line := lines[0]
-	if a, e := line["@level"], "warn"; a != e {
-		t.Errorf("expected module %q, got %q", e, a)
-	}
-	if a, e := line["@module"], expectedModule; a != e {
-		t.Errorf("expected module %q, got %q", e, a)
-	}
-	if a, e := line["@message"], "message"; a != e {
-		t.Errorf("expected message %q, got %q", e, a)
-	}
-	if a, e := line["one"], float64(1); a != e {
-		t.Errorf("expected field \"one\" %v, got %v", e, a)
-	}
-	if a, e := line["two"], "two"; a != e {
-		t.Errorf("expected field \"two\" %q, got %q", e, a)
-	}
+	testLoggerWarn(t, tflogRootName, tfLoggerFactory)
 }
 
 func TestTfLoggerSetField(t *testing.T) {
-	var buf bytes.Buffer
-	ctx := tflogtest.RootLogger(context.Background(), &buf)
+	testLoggerSetField(t, tflogRootName, tfLoggerFactory)
+}
 
-	loggerName := "test"
-	ctx, logger := NewTfLogger(ctx, loggerName)
+func tfLoggerFactory(ctx context.Context, name string, output io.Writer) (context.Context, Logger) {
+	ctx = tflogtest.RootLogger(ctx, output)
 
-	ctxWithField := logger.SetField(ctx, "key", "value")
+	ctx, rootLogger := NewTfLogger(ctx)
+	ctx, logger := rootLogger.SubLogger(ctx, name)
 
-	logger.Warn(ctxWithField, "first")
-	logger.Warn(ctxWithField, "second", map[string]any{
-		"key": "other value",
-	})
-
-	lines, err := tflogtest.MultilineJSONDecode(&buf)
-	if err != nil {
-		t.Fatalf("ctxWithField: decoding log lines: %s", err)
-	}
-
-	line := lines[0]
-	if a, e := line["key"], "value"; a != e {
-		t.Errorf("expected field \"key\" %q, got %q", e, a)
-	}
-
-	line = lines[1]
-	if a, e := line["key"], "other value"; a != e {
-		t.Errorf("expected field \"key\" %q, got %q", e, a)
-	}
-
-	// logger.SetField does not affect the original context
-	logger.Warn(ctx, "no fields")
-
-	lines, err = tflogtest.MultilineJSONDecode(&buf)
-	if err != nil {
-		t.Fatalf("ctx: decoding log lines: %s", err)
-	}
-
-	line = lines[0]
-	if val, ok := line["key"]; ok {
-		t.Errorf("expected field \"key\" to  not be set, got %q", val)
-	}
+	return ctx, logger
 }

--- a/logging/tf_logger_test.go
+++ b/logging/tf_logger_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+)
+
+func TestTfLoggerWarn(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+
+	loggerName := "test"
+	expectedModule := fmt.Sprintf("provider.%s", loggerName)
+	ctx, logger := NewTfLogger(ctx, loggerName)
+
+	logger.Warn(ctx, "message", map[string]any{
+		"one": int(1),
+		"two": "two",
+	})
+
+	lines, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("decoding log lines: %s", err)
+	}
+
+	if l := len(lines); l != 1 {
+		t.Fatalf("expected 1 log entry, got %d\n%v", l, lines)
+	}
+
+	line := lines[0]
+	if a, e := line["@level"], "warn"; a != e {
+		t.Errorf("expected module %q, got %q", e, a)
+	}
+	if a, e := line["@module"], expectedModule; a != e {
+		t.Errorf("expected module %q, got %q", e, a)
+	}
+	if a, e := line["@message"], "message"; a != e {
+		t.Errorf("expected message %q, got %q", e, a)
+	}
+	if a, e := line["one"], float64(1); a != e {
+		t.Errorf("expected field \"one\" %v, got %v", e, a)
+	}
+	if a, e := line["two"], "two"; a != e {
+		t.Errorf("expected field \"two\" %q, got %q", e, a)
+	}
+}
+
+func TestTfLoggerSetField(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+
+	loggerName := "test"
+	ctx, logger := NewTfLogger(ctx, loggerName)
+
+	ctxWithField := logger.SetField(ctx, "key", "value")
+
+	logger.Warn(ctxWithField, "first")
+	logger.Warn(ctxWithField, "second", map[string]any{
+		"key": "other value",
+	})
+
+	lines, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("ctxWithField: decoding log lines: %s", err)
+	}
+
+	line := lines[0]
+	if a, e := line["key"], "value"; a != e {
+		t.Errorf("expected field \"key\" %q, got %q", e, a)
+	}
+
+	line = lines[1]
+	if a, e := line["key"], "other value"; a != e {
+		t.Errorf("expected field \"key\" %q, got %q", e, a)
+	}
+
+	// logger.SetField does not affect the original context
+	logger.Warn(ctx, "no fields")
+
+	lines, err = tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("ctx: decoding log lines: %s", err)
+	}
+
+	line = lines[0]
+	if val, ok := line["key"]; ok {
+		t.Errorf("expected field \"key\" to  not be set, got %q", val)
+	}
+}

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -82,8 +82,8 @@ const loggerName string = "aws-base-v1"
 func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*session.Session, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// var loggerFactory tfLoggerFactory
-	ctx, logger := logging.NewTfLogger(ctx, loggerName)
+	ctx, tflogger := logging.NewTfLogger(ctx)
+	ctx, logger := tflogger.SubLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	options, err := getSessionOptions(ctx, awsC, c)

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -83,7 +83,7 @@ func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*se
 	var diags diag.Diagnostics
 
 	// var loggerFactory tfLoggerFactory
-	ctx, logger := logging.New(ctx, loggerName)
+	ctx, logger := logging.NewTfLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	options, err := getSessionOptions(ctx, awsC, c)

--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -82,8 +82,11 @@ const loggerName string = "aws-base-v1"
 func GetSession(ctx context.Context, awsC *awsv2.Config, c *awsbase.Config) (*session.Session, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	ctx, tflogger := logging.NewTfLogger(ctx)
-	ctx, logger := tflogger.SubLogger(ctx, loggerName)
+	var logger logging.Logger = logging.NullLogger{}
+	if c.Logger != nil {
+		logger = c.Logger
+	}
+	ctx, logger = logger.SubLogger(ctx, loggerName)
 	ctx = logging.RegisterLogger(ctx, logger)
 
 	options, err := getSessionOptions(ctx, awsC, c)

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/diag"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/constants"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/test"
+	"github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/aws-sdk-go-base/v2/servicemocks"
 	"github.com/hashicorp/aws-sdk-go-base/v2/useragent"
 	"github.com/hashicorp/terraform-plugin-log/tflogtest"
@@ -2600,8 +2601,11 @@ func TestLogger(t *testing.T) {
 	oldEnv := servicemocks.InitSessionTestEnv()
 	defer servicemocks.PopEnv(oldEnv)
 
+	ctx, logger := logging.NewTfLogger(ctx)
+
 	config := &awsbase.Config{
 		AccessKey: servicemocks.MockStaticAccessKey,
+		Logger:    logger,
 		Region:    "us-east-1",
 		SecretKey: servicemocks.MockStaticSecretKey,
 	}

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -2564,6 +2564,7 @@ func TestSessionRetryHandlers(t *testing.T) {
 			request, _ := iamconn.GetUserRequest(&iam.GetUserInput{})
 			request.RetryCount = testcase.RetryCount
 			request.Error = testcase.Error
+			request.SetContext(ctx)
 
 			// Prevent the retryer from using the default retry delay
 			retryer := request.Retryer.(client.DefaultRetryer)


### PR DESCRIPTION
Adds support for logging with [`hc-log`](https://github.com/hashicorp/go-hclog) for use with the S3 remote state backend