### PR TITLE
Adds support for regional `us-east-1` S3 endpoint

### DIFF
--- a/v2/awsv1shim/session.go
+++ b/v2/awsv1shim/session.go
@@ -52,6 +52,8 @@ func getSessionOptions(ctx context.Context, awsC *awsv2.Config, c *awsbase.Confi
 			UseFIPSEndpoint:      convertFIPSEndpointState(useFIPSEndpoint),
 			UseDualStackEndpoint: convertDualStackEndpointState(useDualStackEndpoint),
 		},
+		SharedConfigState: session.SharedConfigEnable,
+		SharedConfigFiles: append(c.SharedCredentialsFiles, c.SharedConfigFiles...),
 	}
 
 	if !c.SuppressDebugLog {


### PR DESCRIPTION
Adds support for regional `us-east-1` S3 endpoint in AWS SDK for Go v1

Relates https://github.com/hashicorp/terraform-provider-aws/issues/33028