### PR TITLE
feat: add allowed/forbidden account id fields, verify func

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package config
+
+import (
+	"testing"
+)
+
+func TestConfig_VerifyAccountIDAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    Config
+		accountID string
+		wantErr   bool
+	}{
+		{
+			"empty",
+			Config{},
+			"1234",
+			false,
+		},
+		{
+			"allowed",
+			Config{
+				AllowedAccountIds: []string{"1234"},
+			},
+			"1234",
+			false,
+		},
+		{
+			"not allowed",
+			Config{
+				AllowedAccountIds: []string{"5678"},
+			},
+			"1234",
+			true,
+		},
+		{
+			"forbidden",
+			Config{
+				ForbiddenAccountIds: []string{"1234"},
+			},
+			"1234",
+			true,
+		},
+		{
+			"not forbidden",
+			Config{
+				ForbiddenAccountIds: []string{"5678"},
+			},
+			"1234",
+			false,
+		},
+		{
+			// In practice the upstream interfaces (AWS Provider, S3 Backend, etc.) should make
+			// these conflict, but documenting the behavior for completeness.
+			"allowed and forbidden",
+			Config{
+				AllowedAccountIds:   []string{"1234"},
+				ForbiddenAccountIds: []string{"1234"},
+			},
+			"1234",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.config.VerifyAccountIDAllowed(tt.accountID); (err != nil) != tt.wantErr {
+				t.Errorf("Config.VerifyAccountIDAllowed() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/hashicorp/terraform/issues/33688

Adds `AllowedAccountIds` and `ForbiddenAccountIds` fields to the base `Config` struct, along with a method to verify whether a given account is permitted. This will centralize the logic [currently implemented in AWS Provider](https://github.com/hashicorp/terraform-provider-aws/blob/824f4d9172e86218973a3e997566d725c3a5429e/internal/conns/config.go#L170-L188) to allow for re-use with other upstream interfaces.
