### PR TITLE
Add `tfawserr.ErrHTTPStatusCodeEquals`, AWS SDK for Go v2 variant of `v2/awsv1shim/tfawserr.ErrStatusCodeEquals`

### DIFF
--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	smithy "github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/errs"
 )
 
@@ -31,6 +32,20 @@ func ErrCodeEquals(err error, codes ...string) bool {
 func ErrMessageContains(err error, code string, message string) bool {
 	if apiErr, ok := errs.As[smithy.APIError](err); ok {
 		return apiErr.ErrorCode() == code && strings.Contains(apiErr.ErrorMessage(), message)
+	}
+	return false
+}
+
+// ErrHTTPStatusCodeEquals returns true if the error matches all these conditions:
+//   - err is of type smithyhttp.ResponseError
+//   - ResponseError.HTTPStatusCode() equals one of the passed status codes
+func ErrHTTPStatusCodeEquals(err error, statusCodes ...int) bool {
+	if respErr, ok := errs.As[*smithyhttp.ResponseError](err); ok {
+		for _, statusCode := range statusCodes {
+			if respErr.HTTPStatusCode() == statusCode {
+				return true
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds an AWS SDK for Go v2 variant of the `ErrStatusCodeEquals` helper in `v2/awsv1shim/tfawserr`.
Renamed to better reflect that it's an HTTP status code we're matching on.
Enhanced with varargs list of status codes.

Relates https://github.com/hashicorp/aws-sdk-go-base/pull/524.
Relates https://github.com/hashicorp/aws-sdk-go-base/pull/533.

```console
% go test -v -run=TestErrHTTPStatusCodeEquals ./tfawserr
=== RUN   TestErrHTTPStatusCodeEquals
=== RUN   TestErrHTTPStatusCodeEquals/other_error
=== RUN   TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_matching_first_code
=== RUN   TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_matching_last_code
=== RUN   TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_non-matching_codes
=== RUN   TestErrHTTPStatusCodeEquals/nil_error
=== RUN   TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_matching_first_code
=== RUN   TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_matching_last_code
=== RUN   TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_no_code
=== RUN   TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_non-matching_codes
--- PASS: TestErrHTTPStatusCodeEquals (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/other_error (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_matching_first_code (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_matching_last_code (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Wrapped_smithyhttp.ResponseError_non-matching_codes (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/nil_error (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_matching_first_code (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_matching_last_code (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_no_code (0.00s)
    --- PASS: TestErrHTTPStatusCodeEquals/Top-level_smithyhttp.ResponseError_non-matching_codes (0.00s)
PASS
ok  	github.com/hashicorp/aws-sdk-go-base/v2/tfawserr	0.425s
```