### PR TITLE
feat: add duplicate json key validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable single-title -->
 # v2.0.0 (Unreleased)
 
+# v2.0.0-beta.36 (2023-09-21)
+
+BREAKING CHANGES
+
+* The `ValidateRegion` function has been moved to the `validation` package and renamed to `SupportedRegion` ([#650](https://github.com/hashicorp/aws-sdk-go-base/pull/650))
+
+ENHANCEMENTS
+
+* Adds `JSONNoDuplicateKeys` function to the `validation` package ([#650](https://github.com/hashicorp/aws-sdk-go-base/pull/650))
+
 # v2.0.0-beta.35 (2023-09-05)
 
 ENHANCEMENTS

--- a/validation/json.go
+++ b/validation/json.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DuplicateKeyError is returned when duplicate key names are detected
+// inside a JSON object
+type DuplicateKeyError struct {
+	path []string
+	key  string
+}
+
+func (e *DuplicateKeyError) Error() string {
+	return fmt.Sprintf(`duplicate key "%s"`, strings.Join(append(e.path, e.key), "."))
+}
+
+// JSONNoDuplicateKeys verifies the provided JSON object contains
+// no duplicated keys
+//
+// The function expects a single JSON object, and will error prior to
+// checking for duplicate keys should an invalid input be provided.
+func JSONNoDuplicateKeys(s string) error {
+	var out map[string]any
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return fmt.Errorf("unmarshaling input: %w", err)
+	}
+
+	dec := json.NewDecoder(strings.NewReader(s))
+	return checkToken(dec, nil)
+}
+
+// checkToken walks a JSON object checking for duplicated keys
+//
+// The function is called recursively on the value of each key
+// inside and object, or item inside an array.
+//
+// Adapted from: https://stackoverflow.com/a/50109335
+func checkToken(dec *json.Decoder, path []string) error {
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	delim, ok := t.(json.Delim)
+	if !ok {
+		// non-delimiter, nothing to do
+		return nil
+	}
+
+	var dupErrs []error
+	switch delim {
+	case '{':
+		keys := make(map[string]bool)
+		for dec.More() {
+			// Get the field key
+			t, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			key := t.(string)
+
+			if keys[key] {
+				// Duplicate found
+				dupErrs = append(dupErrs, &DuplicateKeyError{path: path, key: key})
+			}
+			keys[key] = true
+
+			// Check the keys value
+			if err := checkToken(dec, append(path, key)); err != nil {
+				dupErrs = append(dupErrs, err)
+			}
+		}
+
+		// consume trailing "}"
+		_, err := dec.Token()
+		if err != nil {
+			return err
+		}
+	case '[':
+		i := 0
+		for dec.More() {
+			// Check each items value
+			if err := checkToken(dec, append(path, strconv.Itoa(i))); err != nil {
+				dupErrs = append(dupErrs, err)
+			}
+			i++
+		}
+
+		// consume trailing "]"
+		_, err := dec.Token()
+		if err != nil {
+			return err
+		}
+	}
+
+	return errors.Join(dupErrs...)
+}

--- a/validation/json_test.go
+++ b/validation/json_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validation
+
+import (
+	"testing"
+)
+
+func TestJSONNoDuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       string
+		wantErr bool
+	}{
+		{
+			name:    "invalid",
+			s:       "{{{",
+			wantErr: true,
+		},
+		{
+			name: "valid",
+			s: `{
+  "a": "foo",
+  "b": {
+    "c": "bar",
+    "d": [
+      {
+        "e": "baz"
+      },
+      {
+        "f": "qux",
+        "g": "foo"
+      }
+    ]
+  }
+}`,
+			wantErr: false,
+		},
+		{
+			name: "root",
+			s: `{
+  "a": "foo",
+  "a": "bar"
+}`,
+			wantErr: true,
+		},
+		{
+			name: "nested object",
+			s: `{
+  "a": "foo",
+  "b": {
+    "c": "bar",
+    "c": "baz"
+  }
+}`,
+			wantErr: true,
+		},
+		{
+			name: "nested array",
+			s: `{
+  "a": "foo",
+  "b": {
+    "c": "bar",
+    "d": [
+      {
+        "e": "foo",
+        "e": "bar"
+      },
+      {
+        "f": "baz",
+        "g": "qux"
+      }
+    ]
+  }
+}`,
+			wantErr: true,
+		},
+		{
+			name: "multiple",
+			s: `{
+  "a": "foo",
+  "a": "bar",
+  "b": {
+    "c": "baz",
+    "c": "qux",
+    "d": [
+      {
+        "e": "foo"
+      },
+      {
+        "f": "bar",
+        "f": "baz",
+        "g": "qux"
+      }
+    ]
+  }
+}`,
+			wantErr: true,
+		},
+		{
+			name: "aws iam condition keys",
+			s: `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "cloudwatch.amazonaws.com"
+        },
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    }
+  ]
+}`,
+
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := JSONNoDuplicateKeys(tt.s); (err != nil) != tt.wantErr {
+				t.Errorf("JSONNoDuplicateKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/validation/region.go
+++ b/validation/region.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package awsbase
+package validation
 
 import (
 	"fmt"
@@ -17,8 +17,8 @@ func (e *InvalidRegionError) Error() string {
 	return fmt.Sprintf("Invalid AWS Region: %s", e.region)
 }
 
-// ValidateRegion checks if the given region is a valid AWS region.
-func ValidateRegion(region string) error {
+// SupportedRegion checks if the given region is a valid AWS region.
+func SupportedRegion(region string) error {
 	for _, partition := range endpoints.Partitions() {
 		for _, partitionRegion := range partition.Regions() {
 			if region == partitionRegion {

--- a/validation/region_test.go
+++ b/validation/region_test.go
@@ -1,13 +1,13 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package awsbase
+package validation
 
 import (
 	"testing"
 )
 
-func TestValidateRegion(t *testing.T) {
+func TestSupportedRegion(t *testing.T) {
 	var testCases = []struct {
 		Region      string
 		ExpectError bool
@@ -38,7 +38,7 @@ func TestValidateRegion(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Region, func(t *testing.T) {
-			err := ValidateRegion(testCase.Region)
+			err := SupportedRegion(testCase.Region)
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("Expected no error, received error: %s", err)
 			}


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/33026 

Adds a new `ValidateNoDuplicateKeys` function which walks a JSON object checking for duplicate key names. The intention is for `aws-sdk-go-base` to contain the core validation logic (ie. provide a JSON string, get back an error) and allow upstream consumers such as the AWS provider to wrap this function and decide whether to return the findings as a diagnostic warning or error.

Also creates a new `validation` sub-package and moves the one other existing validation function (`ValidateRegion`) into it.

```console
% make test
go test -timeout=30s -parallel=4 ./...
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig      [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/constants      [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/errs   [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/slices [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/internal/test   [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/mockdata        [no test files]
?       github.com/hashicorp/aws-sdk-go-base/v2/servicemocks    [no test files]
ok      github.com/hashicorp/aws-sdk-go-base/v2 5.960s
ok      github.com/hashicorp/aws-sdk-go-base/v2/diag    0.375s
ok      github.com/hashicorp/aws-sdk-go-base/v2/internal/config 0.460s
ok      github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints      0.392s
ok      github.com/hashicorp/aws-sdk-go-base/v2/internal/expand 0.646s
ok      github.com/hashicorp/aws-sdk-go-base/v2/logging 0.484s
ok      github.com/hashicorp/aws-sdk-go-base/v2/tfawserr        0.499s
ok      github.com/hashicorp/aws-sdk-go-base/v2/useragent       0.567s
ok      github.com/hashicorp/aws-sdk-go-base/v2/validation      0.514s
cd v2/awsv1shim && go test -timeout=30s -parallel=4 ./...
?       github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/mockdata   [no test files]
ok      github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2    5.142s
ok      github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr   0.580s
```