### PR TITLE
deps: adjust opentelemetry group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       opentelemetry:
         patterns:
           - "go.opentelemetry.io/otel"
-          - "go.opentelemetry.io/otel/*"
+          - "go.opentelemetry.io/contrib/*"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"


### PR DESCRIPTION
Relates #691 

Fixes the group to properly include the `contrib/*` subpackages.