### PR TITLE
Add `tfawserr.ErrCodeContains`, AWS SDK for Go v2 variant of `v2/awsv1shim/tfawserr.ErrCodeContains`

### DIFF
--- a/tfawserr/awserr.go
+++ b/tfawserr/awserr.go
@@ -25,6 +25,16 @@ func ErrCodeEquals(err error, codes ...string) bool {
 	return false
 }
 
+// ErrCodeContains returns true if the error matches all these conditions:
+//   - err is of type smithy.APIError
+//   - APIError.ErrorCode() contains code
+func ErrCodeContains(err error, code string) bool {
+	if apiErr, ok := errs.As[smithy.APIError](err); ok {
+		return strings.Contains(apiErr.ErrorCode(), code)
+	}
+	return false
+}
+
 // ErrMessageContains returns true if the error matches all these conditions:
 //   - err is of type smithy.APIError
 //   - APIError.ErrorCode() equals code


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Adds an AWS SDK for Go v2 variant of the `ErrCodeContains` helper in `v2/awsv1shim/tfawserr`.

Relates https://github.com/hashicorp/aws-sdk-go-base/pull/642.
Relates https://github.com/hashicorp/aws-sdk-go-base/pull/524.
Relates https://github.com/hashicorp/aws-sdk-go-base/pull/533.

```console
% go test ./tfawserr/...
ok      github.com/hashicorp/aws-sdk-go-base/v2/tfawserr        0.435s
```