### PR TITLE
Add regression check for AWS file parsing

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3610,7 +3610,7 @@ func TestSharedConfigFileParsing(t *testing.T) {
 				config.AddSharedConfigFile(file.Name())
 			}
 
-			ctx, thing := caseDriver.Apply(ctx, t)
+			_, thing := caseDriver.Apply(ctx, t)
 
 			tc.Check(t, thing)
 		})

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3122,6 +3122,14 @@ var _ configtesting.Configurer = &configurer{}
 
 type configurer Config
 
+func (c *configurer) SetAccessKey(s string) {
+	c.AccessKey = s
+}
+
+func (c *configurer) SetSecretKey(s string) {
+	c.SecretKey = s
+}
+
 func (c *configurer) AddEndpoint(k, v string) {
 	switch k {
 	case "sso":
@@ -3145,6 +3153,10 @@ type thing aws.Config
 
 func (t thing) GetCredentials() aws.CredentialsProvider {
 	return t.Credentials
+}
+
+func (t thing) GetRegion() string {
+	return t.Region
 }
 
 func TestSSO(t *testing.T) {
@@ -3535,6 +3547,72 @@ func TestRetryHandlers(t *testing.T) {
 					t.Errorf("expect no attempt to include AttemptResults metadata, %v does, %#v", i, attempt)
 				}
 			}
+		})
+	}
+}
+
+// TestSharedConfigFileParsing prevents regression in shared config file parsing
+// * https://github.com/aws/aws-sdk-go-v2/issues/2349: indented keys
+func TestSharedConfigFileParsing(t *testing.T) {
+	driver := &testDriver{
+		mode: configtesting.TestModeLocal,
+	}
+
+	testcases := map[string]struct {
+		SharedConfigurationFile string
+		Check                   func(t *testing.T, thing configtesting.Thing)
+	}{
+		"leading whitespace": {
+			// Do not "fix" indentation!
+			SharedConfigurationFile: `
+	[default]
+	region = us-west-2
+	`,
+			Check: func(t *testing.T, thing configtesting.Thing) {
+				region := thing.GetRegion()
+				if a, e := region, "us-west-2"; a != e {
+					t.Errorf("expected region %q, got %q", e, a)
+				}
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			caseDriver := driver.TestCase()
+
+			servicemocks.InitSessionTestEnv(t)
+
+			config := caseDriver.Configuration()
+
+			config.SetAccessKey(servicemocks.MockStaticAccessKey)
+			config.SetSecretKey(servicemocks.MockStaticSecretKey)
+
+			if tc.SharedConfigurationFile != "" {
+				file, err := os.CreateTemp("", "aws-sdk-go-base-shared-configuration-file")
+
+				if err != nil {
+					t.Fatalf("unexpected error creating temporary shared configuration file: %s", err)
+				}
+
+				defer os.Remove(file.Name())
+
+				err = os.WriteFile(file.Name(), []byte(tc.SharedConfigurationFile), 0600) //nolint:gomnd
+
+				if err != nil {
+					t.Fatalf("unexpected error writing shared configuration file: %s", err)
+				}
+
+				config.AddSharedConfigFile(file.Name())
+			}
+
+			ctx, thing := caseDriver.Apply(ctx, t)
+
+			tc.Check(t, thing)
 		})
 	}
 }

--- a/configtesting/config.go
+++ b/configtesting/config.go
@@ -36,12 +36,15 @@ type TestCaseDriver interface {
 }
 
 type Configurer interface {
+	SetAccessKey(s string)
+	SetSecretKey(s string)
 	AddEndpoint(k, v string)
 	AddSharedConfigFile(f string)
 }
 
 type Thing interface {
 	GetCredentials() aws.CredentialsProvider
+	GetRegion() string
 }
 
 func SSO(t *testing.T, driver TestDriver) {


### PR DESCRIPTION
Adds regression check for AWS shared config file parsing. Will prevent merging e.g. https://github.com/aws/aws-sdk-go-v2/issues/2349