### PR TITLE
Bump `github.com/aws/aws-sdk-go-v2/service/iam`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.15.1
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.2
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0
-	github.com/aws/aws-sdk-go-v2/service/iam v1.26.0
+	github.com/aws/aws-sdk-go-v2/service/iam v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1 h1:vzYLDkwTw4CY0vUk84MeSufRf8XI
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1/go.mod h1:ToBFBnjeGR2ruMx8IWp/y7vSK3Irj5/oPwifruiqoOM=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0 h1:wAG9NailFhGhg8Ngg2YeCtzGmFWc63SYqJKdvN5ZMkE=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0/go.mod h1:ByrosnNlEq6xkA0d+FwB4f0HH/5KWCcgBqVxAt+Rsps=
-github.com/aws/aws-sdk-go-v2/service/iam v1.26.0 h1:BGEB7NY0e0YZjrQBDN+2kj0ZZg/B5xNjyk0SUjeKuj8=
-github.com/aws/aws-sdk-go-v2/service/iam v1.26.0/go.mod h1:K+kpOBBIGJKPAVdyzzCRR6ssqxpVG6SioxWi2/uWctk=
+github.com/aws/aws-sdk-go-v2/service/iam v1.27.0 h1:Yho1UMoY/Gno30by4l7dXgIdr78t4OuIpw3VT1xz/zE=
+github.com/aws/aws-sdk-go-v2/service/iam v1.27.0/go.mod h1:K+kpOBBIGJKPAVdyzzCRR6ssqxpVG6SioxWi2/uWctk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.0 h1:CJxo7ZBbaIzmXfV3hjcx36n9V87gJsIUPJflwqEHl3Q=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.0/go.mod h1:yjVfjuY4nD1EW9i387Kau+I6V5cBA5YnC/mWNopjZrI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.1 h1:15FUCJzAP9Y25nioTqTrGlZmhOtthaXBWlt4pS+d3Xo=

--- a/v2/awsv1shim/go.mod
+++ b/v2/awsv1shim/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/iam v1.26.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/iam v1.27.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.8.1 // indirect

--- a/v2/awsv1shim/go.sum
+++ b/v2/awsv1shim/go.sum
@@ -20,8 +20,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1 h1:vzYLDkwTw4CY0vUk84MeSufRf8XI
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.1/go.mod h1:ToBFBnjeGR2ruMx8IWp/y7vSK3Irj5/oPwifruiqoOM=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0 h1:wAG9NailFhGhg8Ngg2YeCtzGmFWc63SYqJKdvN5ZMkE=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.0/go.mod h1:ByrosnNlEq6xkA0d+FwB4f0HH/5KWCcgBqVxAt+Rsps=
-github.com/aws/aws-sdk-go-v2/service/iam v1.26.0 h1:BGEB7NY0e0YZjrQBDN+2kj0ZZg/B5xNjyk0SUjeKuj8=
-github.com/aws/aws-sdk-go-v2/service/iam v1.26.0/go.mod h1:K+kpOBBIGJKPAVdyzzCRR6ssqxpVG6SioxWi2/uWctk=
+github.com/aws/aws-sdk-go-v2/service/iam v1.27.0 h1:Yho1UMoY/Gno30by4l7dXgIdr78t4OuIpw3VT1xz/zE=
+github.com/aws/aws-sdk-go-v2/service/iam v1.27.0/go.mod h1:K+kpOBBIGJKPAVdyzzCRR6ssqxpVG6SioxWi2/uWctk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.0 h1:CJxo7ZBbaIzmXfV3hjcx36n9V87gJsIUPJflwqEHl3Q=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.0/go.mod h1:yjVfjuY4nD1EW9i387Kau+I6V5cBA5YnC/mWNopjZrI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.1 h1:15FUCJzAP9Y25nioTqTrGlZmhOtthaXBWlt4pS+d3Xo=


### PR DESCRIPTION
Bump `github.com/aws/aws-sdk-go-v2/service/iam` from `v1.26.0` to `v1.27.0`
