### PR TITLE
Remove `go.mod` `aws-sdk-go-v2` exclusions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,11 +51,3 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-exclude ( // Contains INI parsing regression
-	github.com/aws/aws-sdk-go-v2/config v1.21.0
-	github.com/aws/aws-sdk-go-v2/config v1.22.0
-	github.com/aws/aws-sdk-go-v2/config v1.25.0
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.0
-)

--- a/v2/awsv1shim/go.mod
+++ b/v2/awsv1shim/go.mod
@@ -55,9 +55,3 @@ require (
 )
 
 replace github.com/hashicorp/aws-sdk-go-base/v2 => ../..
-
-exclude ( // Contains INI parsing regression
-	github.com/aws/aws-sdk-go-v2/config v1.21.0
-	github.com/aws/aws-sdk-go-v2/config v1.22.0
-	github.com/aws/aws-sdk-go-v2/internal/ini v1.5.0
-)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Removes the `aws-sdk-go-v2` `go.mod` exclusions added for INI file parsing bugs. https://github.com/aws/aws-sdk-go-v2/pull/2365 and https://github.com/aws/aws-sdk-go-v2/pull/2371 and _should_ have resolved them all.
We need to use `aws-sdk-go-v2` module versions released since https://github.com/aws/aws-sdk-go-v2/pull/2364, and the exclusions were preventing this.

Closes https://github.com/hashicorp/aws-sdk-go-base/issues/783.
Relates https://github.com/aws/aws-sdk-go-v2/issues/2370.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/34425.
