### PR TITLE
Reduces allocations and improves performance in `logging.partialMaskString`

### DIFF
--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -100,11 +100,41 @@ func TestMaskAWSSensitiveValues(t *testing.T) {
 	}
 }
 
+func BenchmarkMaskAWSAccessKey(b *testing.B) {
+	var s string
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		s = MaskAWSAccessKey(`
+{
+	"AWSSecretKey": "LEfH8nZmFN4BGIJnku6lkChHydRN5B/YlWCIjOte",
+	"BucketName": "test-bucket",
+	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
+}
+`)
+	}
+	dump = s
+}
+
 func BenchmarkPartialMaskString(b *testing.B) {
 	var s string
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		s = partialMaskString("AIDACKCEVSQ6C2EXAMPLE", 4, 4)
+	}
+	dump = s
+}
+
+func BenchmarkMaskAWSSecretKeys(b *testing.B) {
+	var s string
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		s = MaskAWSSecretKeys(`
+{
+	"AWSSecretKey": "LEfH8nZmFN4BGIJnku6lkChHydRN5B/YlWCIjOte",
+	"BucketName": "test-bucket",
+	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
+}
+`)
 	}
 	dump = s
 }

--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -99,3 +99,14 @@ func TestMaskAWSSensitiveValues(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkPartialMaskString(b *testing.B) {
+	var s string
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		s = partialMaskString("AIDACKCEVSQ6C2EXAMPLE", 4, 4)
+	}
+	dump = s
+}
+
+var dump string

--- a/logging/mask.go
+++ b/logging/mask.go
@@ -9,8 +9,12 @@ import (
 
 func partialMaskString(s string, first, last int) string {
 	l := len(s)
-	result := s[0:first]
-	result += strings.Repeat("*", l-first-last)
-	result += s[l-last:]
-	return result
+	result := strings.Builder{}
+	result.Grow(l)
+	result.WriteString(s[0:first])
+	for i := 0; i < l-first-last; i++ {
+		result.WriteByte('*')
+	}
+	result.WriteString(s[l-last:])
+	return result.String()
 }


### PR DESCRIPTION
`logging.partialMaskString` is potentially used many times when logging

Previosly, `logging.partialMaskString` had the benchmark result

> BenchmarkPartialMaskString-10    	12607579	       108.6 ns/op	      64 B/op	       3 allocs/op

Now, the benchmark is

> BenchmarkPartialMaskString-10    	25722277	        51.20 ns/op	      24 B/op	       1 allocs/op
