### PR TITLE
Reduces allocations in log masking

### DIFF
--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -139,4 +139,19 @@ func BenchmarkMaskAWSSecretKeys(b *testing.B) {
 	dump = s
 }
 
+func BenchmarkMaskAWSSensitiveValues(b *testing.B) {
+	var s string
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		s = MaskAWSSensitiveValues(`
+{
+	"AWSSecretKey": "LEfH8nZmFN4BGIJnku6lkChHydRN5B/YlWCIjOte",
+	"BucketName": "test-bucket",
+	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
+}
+`)
+	}
+	dump = s
+}
+
 var dump string

--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -5,6 +5,7 @@ package logging
 
 import (
 	"testing"
+	"unsafe"
 )
 
 func TestMaskAWSSensitiveValues(t *testing.T) {
@@ -101,42 +102,38 @@ func TestMaskAWSSensitiveValues(t *testing.T) {
 }
 
 func BenchmarkMaskAWSAccessKey(b *testing.B) {
-	var s string
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		s = MaskAWSAccessKey(`
+		MaskAWSAccessKey([]byte(`
 {
 	"AWSSecretKey": "LEfH8nZmFN4BGIJnku6lkChHydRN5B/YlWCIjOte",
 	"BucketName": "test-bucket",
 	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
 }
-`)
+`))
 	}
-	dump = s
 }
 
 func BenchmarkPartialMaskString(b *testing.B) {
-	var s string
+	var s []byte
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		s = partialMaskString("AIDACKCEVSQ6C2EXAMPLE", 4, 4)
+		s = partialMaskString([]byte("AIDACKCEVSQ6C2EXAMPLE"), 4, 4)
 	}
-	dump = s
+	dump = unsafe.String(unsafe.SliceData(s), len(s))
 }
 
 func BenchmarkMaskAWSSecretKeys(b *testing.B) {
-	var s string
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		s = MaskAWSSecretKeys(`
+		MaskAWSSecretKeys([]byte(`
 {
 	"AWSSecretKey": "LEfH8nZmFN4BGIJnku6lkChHydRN5B/YlWCIjOte",
 	"BucketName": "test-bucket",
 	"AWSKeyId": "AIDACKCEVSQ6C2EXAMPLE",
 }
-`)
+`))
 	}
-	dump = s
 }
 
 func BenchmarkMaskAWSSensitiveValues(b *testing.B) {

--- a/logging/mask.go
+++ b/logging/mask.go
@@ -3,18 +3,13 @@
 
 package logging
 
-import (
-	"strings"
-)
-
-func partialMaskString(s string, first, last int) string {
+func partialMaskString(s []byte, first, last int) []byte {
 	l := len(s)
-	result := strings.Builder{}
-	result.Grow(l)
-	result.WriteString(s[0:first])
+	result := make([]byte, 0, l)
+	result = append(result, s[0:first]...)
 	for i := 0; i < l-first-last; i++ {
-		result.WriteByte('*')
+		result = append(result, '*')
 	}
-	result.WriteString(s[l-last:])
-	return result.String()
+	result = append(result, s[l-last:]...)
+	return result
 }


### PR DESCRIPTION
Reduces memory allocations and improves performance in log field masking

Previously:

```
BenchmarkMaskAWSAccessKey-10          	 1805671	       662.4 ns/op	     523 B/op	       5 allocs/op
BenchmarkPartialMaskString-10         	28668325	        43.01 ns/op	      24 B/op	       1 allocs/op
BenchmarkMaskAWSSecretKeys-10         	 5249382	       229.6 ns/op	     288 B/op	       2 allocs/op
BenchmarkMaskAWSSensitiveValues-10    	 1315366	       912.7 ns/op	     814 B/op	       7 allocs/op
```

Now:

```
BenchmarkMaskAWSAccessKey-10          	 1798647	       669.0 ns/op	     523 B/op	       5 allocs/op
BenchmarkPartialMaskString-10         	58013986	        20.65 ns/op	      24 B/op	       1 allocs/op
BenchmarkMaskAWSSecretKeys-10         	 7040124	       168.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkMaskAWSSensitiveValues-10    	 1520526	       790.6 ns/op	     378 B/op	       4 allocs/op
```