### PR TITLE
Cleans up diags checks in tests

### DIFF
--- a/internal/test/validator.go
+++ b/internal/test/validator.go
@@ -41,17 +41,6 @@ func ExpectDiagValidator(msg string, dv DiagValidator) DiagsValidator {
 	}
 }
 
-func ExpectWarningDiagValidator(expected diag.Diagnostic) DiagsValidator {
-	return func(t *testing.T, diags diag.Diagnostics) {
-		// Check for the correct type of error before checking for single diagnostic
-		if !expectDiagsContainsDiag(diags, expected) {
-			t.Fatalf("expected Diagnostic matching %#v, got %#v", expected, diags)
-		}
-
-		expectDiagsCount(t, diags, 1)
-	}
-}
-
 func expectDiagsCount(t *testing.T, diags diag.Diagnostics, c int) {
 	if l := diags.Count(); l != c {
 		t.Fatalf("Diagnostics: expected %d element, got %d\n%#v", c, l, diags)

--- a/internal/test/validator.go
+++ b/internal/test/validator.go
@@ -58,15 +58,6 @@ func expectDiagsContainsErr(diags diag.Diagnostics, ev ErrValidator) bool {
 	return false
 }
 
-func expectDiagsContainsDiag(diags diag.Diagnostics, expected diag.Diagnostic) bool {
-	for _, d := range diags {
-		if d.Equal(expected) {
-			return true
-		}
-	}
-	return false
-}
-
 func expectDiagsContainsDiagFunc(diags diag.Diagnostics, dv DiagValidator) bool {
 	for _, d := range diags {
 		if dv(d) {

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -1920,7 +1920,7 @@ func TestAssumeRole(t *testing.T) {
 		Config                   *awsbase.Config
 		SharedConfigurationFile  string
 		ExpectedCredentialsValue credentials.Value
-		ValidateDiags            test.DiagsValidator
+		ExpectedDiags            diag.Diagnostics
 		MockStsEndpoints         []*servicemocks.MockEndpoint
 	}{
 		"config": {
@@ -2020,21 +2020,17 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 				SecretKey:  servicemocks.MockStaticSecretKey,
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleCredentials,
-			ValidateDiags: test.ExpectDiagValidator(`"role ARN not set" error`, func(d diag.Diagnostic) bool {
-				return d.Equal(diag.NewErrorDiagnostic(
+			ExpectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
 					"Cannot assume IAM Role",
 					"IAM Role ARN not set",
-				))
-			}),
+				),
+			},
 		},
 	}
 
 	for testName, testCase := range testCases {
 		testCase := testCase
-
-		if testCase.ValidateDiags == nil {
-			testCase.ValidateDiags = test.ExpectNoDiags
-		}
 
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
@@ -2081,7 +2077,9 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 
 			ctx, awsConfig, diags := awsbase.GetAwsConfig(ctx, testCase.Config)
 
-			testCase.ValidateDiags(t, diags)
+			if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
+				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
+			}
 			if diags.HasError() {
 				return
 			}

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -2117,7 +2117,7 @@ func TestAssumeRoleWithWebIdentity(t *testing.T) {
 		SharedConfigurationFile    string
 		SetSharedConfigurationFile bool
 		ExpectedCredentialsValue   credentials.Value
-		ValidateDiags              test.DiagsValidator
+		ExpectedDiags              diag.Diagnostics
 		MockStsEndpoints           []*servicemocks.MockEndpoint
 	}{
 		"config with inline token": {
@@ -2297,10 +2297,12 @@ web_identity_token_file = no-such-file
 				AssumeRoleWithWebIdentity: &awsbase.AssumeRoleWithWebIdentity{},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
-			ValidateDiags: test.ExpectWarningDiagValidator(diag.NewErrorDiagnostic(
-				"Assume Role With Web Identity",
-				"Role ARN was not set",
-			)),
+			ExpectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Assume Role With Web Identity",
+					"Role ARN was not set",
+				),
+			},
 		},
 
 		"invalid no token": {
@@ -2310,19 +2312,17 @@ web_identity_token_file = no-such-file
 				},
 			},
 			ExpectedCredentialsValue: mockdata.MockStsAssumeRoleWithWebIdentityCredentials,
-			ValidateDiags: test.ExpectWarningDiagValidator(diag.NewErrorDiagnostic(
-				"Assume Role With Web Identity",
-				"One of WebIdentityToken, WebIdentityTokenFile must be set",
-			)),
+			ExpectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Assume Role With Web Identity",
+					"One of WebIdentityToken, WebIdentityTokenFile must be set",
+				),
+			},
 		},
 	}
 
 	for testName, testCase := range testCases {
 		testCase := testCase
-
-		if testCase.ValidateDiags == nil {
-			testCase.ValidateDiags = test.ExpectNoDiags
-		}
 
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
@@ -2410,7 +2410,9 @@ web_identity_token_file = no-such-file
 
 			ctx, awsConfig, diags := awsbase.GetAwsConfig(ctx, testCase.Config)
 
-			testCase.ValidateDiags(t, diags)
+			if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
+				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
+			}
 			if diags.HasError() {
 				return
 			}


### PR DESCRIPTION
Replaces uses of `DiagsValidator` with lists of expected diags