### PR TITLE
Enables configurable API endpoints

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3091,7 +3091,7 @@ func TestStsEndpoint(t *testing.T) {
 		ConfigFile          string
 		ExpectedCredentials aws.Credentials
 	}{
-		"config": {
+		"service config": {
 			Config: Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				Region:    "us-east-1",
@@ -3099,6 +3099,39 @@ func TestStsEndpoint(t *testing.T) {
 			},
 			SetServiceEndpoint:  setValid,
 			ExpectedCredentials: mockdata.MockStaticCredentials,
+		},
+
+		"service config overrides service envvar": {
+			Config: Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SetServiceEndpoint:  setValid,
+			SetInvalidEnv:       "AWS_ENDPOINT_URL_STS",
+			ExpectedCredentials: mockdata.MockStaticCredentials,
+		},
+
+		"service config overrides service config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+services = sts-test
+
+[services sts-test]
+sts =
+	endpoint_url = %[2]s
+`,
+			SetServiceEndpoint: setValid,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
 		},
 
 		"service envvar": {

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3076,11 +3076,17 @@ web_identity_token_file = no-such-file
 }
 
 func TestStsEndpoint(t *testing.T) {
+	type settype int
+	const (
+		setNone settype = iota
+		setValid
+		setInvalid
+	)
 	testcases := map[string]struct {
-		Config        Config
-		SetConfig     bool
-		SetEnv        string
-		SetInvalidEnv string
+		Config             Config
+		SetServiceEndpoint settype
+		SetEnv             string
+		SetInvalidEnv      string
 		// Use string at index 1 for valid endpoint url and index 2 for invalid endpoint url
 		ConfigFile          string
 		ExpectedCredentials aws.Credentials
@@ -3091,7 +3097,7 @@ func TestStsEndpoint(t *testing.T) {
 				Region:    "us-east-1",
 				SecretKey: servicemocks.MockStaticSecretKey,
 			},
-			SetConfig:           true,
+			SetServiceEndpoint:  setValid,
 			ExpectedCredentials: mockdata.MockStaticCredentials,
 		},
 
@@ -3287,7 +3293,7 @@ endpoint_url = %[2]s
 			defer invalidTS.Close()
 			stsInvalidEndpoint := invalidTS.URL
 
-			if testcase.SetConfig {
+			if testcase.SetServiceEndpoint == setValid {
 				testcase.Config.StsEndpoint = stsEndpoint
 			}
 			if testcase.SetEnv != "" {

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3126,26 +3126,26 @@ func TestStsEndpoint(t *testing.T) {
 			ExpectedCredentials: mockdata.MockStaticCredentials,
 		},
 
-		// 		"service config_file": {
-		// 			Config: Config{
-		// 				Profile: "default",
-		// 			},
-		// 			ConfigFile: `
-		// [default]
-		// aws_access_key_id = DefaultSharedCredentialsAccessKey
-		// aws_secret_access_key = DefaultSharedCredentialsSecretKey
-		// services = sts-test
+		"service config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+services = sts-test
 
-		// [services sts-test]
-		// sts =
-		// 	endpoint_url = %s
-		// `,
-		// 			ExpectedCredentials: aws.Credentials{
-		// 				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
-		// 				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
-		// 				Source:          sharedConfigCredentialsProvider,
-		// 			},
-		// 		},
+[services sts-test]
+sts =
+	endpoint_url = %s
+`,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+		},
 
 		// TODO: service envvar overrides service config_file
 

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3191,7 +3191,27 @@ sts =
 			},
 		},
 
-		// TODO: does global envvar override service config_file?
+		"global envvar overrides service config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			SetEnv: "AWS_ENDPOINT_URL",
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+services = sts-test
+
+[services sts-test]
+sts =
+	endpoint_url = %[2]s
+`,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+		},
 
 		"global config_file": {
 			Config: Config{

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3169,7 +3169,27 @@ sts =
 			},
 		},
 
-		// TODO: service envvar overrides service config_file
+		"service envvar overrides service config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			SetEnv: "AWS_ENDPOINT_URL_STS",
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+services = sts-test
+
+[services sts-test]
+sts =
+	endpoint_url = %[2]s
+`,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+		},
 
 		// TODO: does global envvar override service config_file?
 

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3077,12 +3077,12 @@ web_identity_token_file = no-such-file
 
 func TestStsEndpoint(t *testing.T) {
 	testcases := map[string]struct {
-		Config              Config
-		SetConfig           bool
-		SetEnv              string
-		SetInvalidEnv       string
+		Config        Config
+		SetConfig     bool
+		SetEnv        string
+		SetInvalidEnv string
+		// Use string at index 1 for valid endpoint url and index 2 for invalid endpoint url
 		ConfigFile          string
-		InvalidConfigFile   string
 		ExpectedCredentials aws.Credentials
 	}{
 		"config": {
@@ -3138,7 +3138,7 @@ services = sts-test
 
 [services sts-test]
 sts =
-	endpoint_url = %s
+	endpoint_url = %[1]s
 `,
 			ExpectedCredentials: aws.Credentials{
 				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
@@ -3159,7 +3159,7 @@ sts =
 [default]
 aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
-endpoint_url = %s
+endpoint_url = %[1]s
 `,
 			ExpectedCredentials: aws.Credentials{
 				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
@@ -3173,11 +3173,11 @@ endpoint_url = %s
 				Profile: "default",
 			},
 			SetEnv: "AWS_ENDPOINT_URL",
-			InvalidConfigFile: `
+			ConfigFile: `
 [default]
 aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
-endpoint_url = %s
+endpoint_url = %[2]s
 `,
 			ExpectedCredentials: aws.Credentials{
 				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
@@ -3191,11 +3191,11 @@ endpoint_url = %s
 				Profile: "default",
 			},
 			SetEnv: "AWS_ENDPOINT_URL_STS",
-			InvalidConfigFile: `
+			ConfigFile: `
 [default]
 aws_access_key_id = DefaultSharedCredentialsAccessKey
 aws_secret_access_key = DefaultSharedCredentialsSecretKey
-endpoint_url = %s
+endpoint_url = %[2]s
 `,
 			ExpectedCredentials: aws.Credentials{
 				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
@@ -3236,12 +3236,7 @@ endpoint_url = %s
 			}
 			if testcase.ConfigFile != "" {
 				tempDir := t.TempDir()
-				filename := writeSharedConfigFile(t, &testcase.Config, tempDir, fmt.Sprintf(testcase.ConfigFile, stsEndpoint))
-				testcase.ExpectedCredentials.Source = sharedConfigCredentialsSource(filename)
-			}
-			if testcase.InvalidConfigFile != "" {
-				tempDir := t.TempDir()
-				filename := writeSharedConfigFile(t, &testcase.Config, tempDir, fmt.Sprintf(testcase.InvalidConfigFile, stsInvalidEndpoint))
+				filename := writeSharedConfigFile(t, &testcase.Config, tempDir, fmt.Sprintf(testcase.ConfigFile, stsEndpoint, stsInvalidEndpoint))
 				testcase.ExpectedCredentials.Source = sharedConfigCredentialsSource(filename)
 			}
 

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3105,7 +3105,7 @@ func TestStsEndpoint(t *testing.T) {
 			ExpectedCredentials: mockdata.MockStaticCredentials,
 		},
 
-		"global envvar": {
+		"base envvar": {
 			Config: Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				Region:    "us-east-1",
@@ -3115,7 +3115,7 @@ func TestStsEndpoint(t *testing.T) {
 			ExpectedCredentials: mockdata.MockStaticCredentials,
 		},
 
-		"service envvar overrides global envvar": {
+		"service envvar overrides base envvar": {
 			Config: Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				Region:    "us-east-1",
@@ -3147,7 +3147,7 @@ sts =
 			},
 		},
 
-		"service config_file overrides global config_file": {
+		"service config_file overrides base config_file": {
 			Config: Config{
 				Profile: "default",
 			},
@@ -3191,7 +3191,7 @@ sts =
 			},
 		},
 
-		"global envvar overrides service config_file": {
+		"base envvar overrides service config_file": {
 			Config: Config{
 				Profile: "default",
 			},
@@ -3213,7 +3213,7 @@ sts =
 			},
 		},
 
-		"global config_file": {
+		"base config_file": {
 			Config: Config{
 				Profile: "default",
 			},
@@ -3230,7 +3230,7 @@ endpoint_url = %[1]s
 			},
 		},
 
-		"global envvar overrides global config_file": {
+		"base envvar overrides base config_file": {
 			Config: Config{
 				Profile: "default",
 			},
@@ -3248,7 +3248,7 @@ endpoint_url = %[2]s
 			},
 		},
 
-		"service envvar overrides global config_file": {
+		"service envvar overrides base config_file": {
 			Config: Config{
 				Profile: "default",
 			},

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3147,6 +3147,28 @@ sts =
 			},
 		},
 
+		"service config_file overrides global config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+services = sts-test
+endpoint_url = %[2]s
+
+[services sts-test]
+sts =
+	endpoint_url = %[1]s
+`,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+		},
+
 		// TODO: service envvar overrides service config_file
 
 		// TODO: does global envvar override service config_file?

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -3112,6 +3112,17 @@ func TestStsEndpoint(t *testing.T) {
 			ExpectedCredentials: mockdata.MockStaticCredentials,
 		},
 
+		"service config overrides base envvar": {
+			Config: Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			SetServiceEndpoint:  setValid,
+			SetInvalidEnv:       "AWS_ENDPOINT_URL",
+			ExpectedCredentials: mockdata.MockStaticCredentials,
+		},
+
 		"service config overrides service config_file": {
 			Config: Config{
 				Profile: "default",
@@ -3125,6 +3136,24 @@ services = sts-test
 [services sts-test]
 sts =
 	endpoint_url = %[2]s
+`,
+			SetServiceEndpoint: setValid,
+			ExpectedCredentials: aws.Credentials{
+				AccessKeyID:     "DefaultSharedCredentialsAccessKey",
+				SecretAccessKey: "DefaultSharedCredentialsSecretKey",
+				Source:          sharedConfigCredentialsProvider,
+			},
+		},
+
+		"service config overrides base config_file": {
+			Config: Config{
+				Profile: "default",
+			},
+			ConfigFile: `
+[default]
+aws_access_key_id = DefaultSharedCredentialsAccessKey
+aws_secret_access_key = DefaultSharedCredentialsSecretKey
+endpoint_url = %[2]s
 `,
 			SetServiceEndpoint: setValid,
 			ExpectedCredentials: aws.Credentials{


### PR DESCRIPTION
Enables configuring API endpoints using environment variables and shared config files using AWS SDK. Requires AWS SDK update.

Closes #602