### PR TITLE
Add `Config.TokenBucketRateLimiterCapacity`

### DIFF
--- a/aws_config.go
+++ b/aws_config.go
@@ -211,7 +211,7 @@ func resolveRetryer(ctx context.Context, tokenBucketRateLimiterCapacity int, aws
 	newRetryer := func(retryMode aws.RetryMode, standardOptions []func(*retry.StandardOptions), tokenBucketRateLimiterCapacity int) aws.RetryerV2 {
 		var retryer aws.RetryerV2
 
-		if tokenBucketRateLimiterCapacity >= 0 {
+		if tokenBucketRateLimiterCapacity > 0 {
 			standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
 				so.RateLimiter = ratelimit.NewTokenRateLimit(uint(tokenBucketRateLimiterCapacity))
 			})

--- a/aws_config.go
+++ b/aws_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -28,6 +29,7 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints"
 	"github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"golang.org/x/exp/slices"
 )
 
 const loggerName string = "aws-base"
@@ -173,7 +175,7 @@ func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, 
 		}
 	}
 
-	resolveRetryer(baseCtx, &awsConfig)
+	resolveRetryer(baseCtx, c.TokenBucketRateLimiterCapacity, &awsConfig)
 
 	if !c.SkipCredsValidation {
 		if _, _, err := getAccountIDAndPartitionFromSTSGetCallerIdentity(baseCtx, stsClient(baseCtx, awsConfig, c)); err != nil {
@@ -186,7 +188,7 @@ func GetAwsConfig(ctx context.Context, c *Config) (context.Context, aws.Config, 
 
 // Adapted from the per-service-client `resolveRetryer()` functions in the AWS SDK for Go v2
 // e.g. https://github.com/aws/aws-sdk-go-v2/blob/main/service/accessanalyzer/api_client.go
-func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
+func resolveRetryer(ctx context.Context, tokenBucketRateLimiterCapacity int, awsConfig *aws.Config) {
 	retryMode := awsConfig.RetryMode
 	if len(retryMode) == 0 {
 		defaultsMode := resolveDefaultsMode(ctx, awsConfig)
@@ -206,8 +208,15 @@ func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
 		})
 	}
 
-	newRetryer := func(retryMode aws.RetryMode, standardOptions []func(*retry.StandardOptions)) aws.RetryerV2 {
+	newRetryer := func(retryMode aws.RetryMode, standardOptions []func(*retry.StandardOptions), tokenBucketRateLimiterCapacity int) aws.RetryerV2 {
 		var retryer aws.RetryerV2
+
+		if tokenBucketRateLimiterCapacity >= 0 {
+			standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
+				so.RateLimiter = ratelimit.NewTokenRateLimit(uint(tokenBucketRateLimiterCapacity))
+			})
+		}
+
 		switch retryMode {
 		case aws.RetryModeAdaptive:
 			var adaptiveOptions []func(*retry.AdaptiveModeOptions)
@@ -228,7 +237,7 @@ func resolveRetryer(ctx context.Context, awsConfig *aws.Config) {
 	awsConfig.Retryer = func() aws.Retryer {
 		return &networkErrorShortcutter{
 			// Ensure that each invocation of this function returns an independent Retryer.
-			RetryerV2: newRetryer(retryMode, standardOptions),
+			RetryerV2: newRetryer(retryMode, slices.Clone(standardOptions), tokenBucketRateLimiterCapacity),
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	StsRegion                      string
 	SuppressDebugLog               bool
 	Token                          string
+	TokenBucketRateLimiterCapacity int
 	UseDualStackEndpoint           bool
 	UseFIPSEndpoint                bool
 	UseLegacyWorkflow              bool


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes https://github.com/hashicorp/aws-sdk-go-base/issues/932.

Adds `TokenBucketRateLimiterCapacity` to the `Config` structure and uses its value (if > 0) to configure `aws-sdk-go-v2` token bucket rate limiter capacity.

```console
% go test ./...                                                     
?   	github.com/hashicorp/aws-sdk-go-base/v2/configtesting	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/constants	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/errs	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/slices	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/test	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/mockdata	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/servicemocks	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2	7.139s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/diag	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/config	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/expand	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/logging	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/tfawserr	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/useragent	(cached)
ok  	github.com/hashicorp/aws-sdk-go-base/v2/validation	(cached)
```
