### PR TITLE
internal/config: remove UseLegacyWorkflow option

### DIFF
--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -1036,32 +1036,6 @@ aws_access_key_id = ProfileSharedCredentialsAccessKey
 aws_secret_access_key = ProfileSharedCredentialsSecretKey
 `,
 		},
-		{
-			Config: &Config{
-				Profile:           "SharedCredentialsProfile",
-				Region:            "us-east-1",
-				UseLegacyWorkflow: true,
-			},
-			Description: "environment AWS_ACCESS_KEY_ID overrides config Profile in legacy workflow",
-			EnvironmentVariables: map[string]string{
-				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
-				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
-			},
-			ExpectedCredentialsValue: mockdata.MockEnvCredentials,
-			ExpectedRegion:           "us-east-1",
-			MockStsEndpoints: []*servicemocks.MockEndpoint{
-				servicemocks.MockStsGetCallerIdentityValidEndpoint,
-			},
-			SharedCredentialsFile: `
-[default]
-aws_access_key_id = DefaultSharedCredentialsAccessKey
-aws_secret_access_key = DefaultSharedCredentialsSecretKey
-
-[SharedCredentialsProfile]
-aws_access_key_id = ProfileSharedCredentialsAccessKey
-aws_secret_access_key = ProfileSharedCredentialsSecretKey
-`,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/credentials.go
+++ b/credentials.go
@@ -45,17 +45,9 @@ func getCredentialsProvider(ctx context.Context, c *Config) (aws.CredentialsProv
 	}
 
 	if c.Profile != "" && os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
-		if c.UseLegacyWorkflow {
-			diags.AddWarning("Configuration conflict overridden",
-				`A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
-					`The legacy workflow is enabled, so the Profile will be ignored in favor of the environment variable credentials. `+
-					`This behavior may be removed in the future.`)
-			c.Profile = ""
-		} else {
-			diags.AddWarning("Configuration conflict detected",
-				`A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
-					`The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.`)
-		}
+		diags.AddWarning("Configuration conflict detected",
+			`A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". `+
+				`The Profile is now used instead of the environment variable credentials. This may lead to unexpected behavior.`)
 	}
 
 	if profile := c.Profile; profile != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,6 @@ type Config struct {
 	TokenBucketRateLimiterCapacity int
 	UseDualStackEndpoint           bool
 	UseFIPSEndpoint                bool
-	UseLegacyWorkflow              bool
 	UserAgent                      UserAgentProducts
 }
 


### PR DESCRIPTION
This option was added to temporarily enable the legacy credential chain evaluation order from V1 of this library to be adopted within V2. As of Terraform 1.8, the ability to use this legacy behavior has been completely removed, and the credential chain is always evaluated in the same order as the AWS SDK. As this option is no longer in use by any consumers of this library, it can be safely removed here.

Closes #946 
Relates #595 
Relates https://github.com/hashicorp/terraform/pull/34723