### PR TITLE
Fix minor regression on custom User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable single-title -->
 # v2.0.0 (Unreleased)
 
+BUG FIXES
+
+* Correctly handles user agents passed using `TF_APPEND_USER_AGENT` which contain `/`,  `(`, `)`, or space ([#990](https://github.com/hashicorp/aws-sdk-go-base/pull/990))
+
 # v2.0.0-beta.50 (2024-03-19)
 
 BUG FIXES

--- a/aws_config.go
+++ b/aws_config.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
-	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -357,7 +356,7 @@ func commonLoadOptions(ctx context.Context, c *Config) ([]func(*config.LoadOptio
 	}
 
 	if len(c.UserAgent) > 0 {
-		apiOptions = append(apiOptions, withUserAgentAppender(c.UserAgent))
+		apiOptions = append(apiOptions, withUserAgentAppender(c.UserAgent.BuildUserAgentString()))
 	}
 
 	apiOptions = append(apiOptions, func(stack *middleware.Stack) error {
@@ -369,7 +368,7 @@ func commonLoadOptions(ctx context.Context, c *Config) ([]func(*config.LoadOptio
 			"source": fmt.Sprintf("envvar(%q)", constants.AppendUserAgentEnvVar),
 			"value":  v,
 		})
-		apiOptions = append(apiOptions, awsmiddleware.AddUserAgentKey(v))
+		apiOptions = append(apiOptions, withUserAgentAppender(v))
 	}
 
 	if !c.SuppressDebugLog {

--- a/internal/test/user_agent.go
+++ b/internal/test/user_agent.go
@@ -36,9 +36,9 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 				SecretKey: servicemocks.MockStaticSecretKey,
 			},
 			EnvironmentVariables: map[string]string{
-				constants.AppendUserAgentEnvVar: "Last",
+				constants.AppendUserAgentEnvVar: "Last/9.0.0",
 			},
-			ExpectedUserAgent: awsSdkGoUserAgent() + " Last",
+			ExpectedUserAgent: awsSdkGoUserAgent() + " Last/9.0.0",
 		},
 		"APN User-Agent Products": {
 			Config: &config.Config{
@@ -82,9 +82,9 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 				},
 			},
 			EnvironmentVariables: map[string]string{
-				constants.AppendUserAgentEnvVar: "Last",
+				constants.AppendUserAgentEnvVar: "Last/9.0.0",
 			},
-			ExpectedUserAgent: "APN/1.0 partner/1.0 first/1.2.3 second/1.0.2 " + awsSdkGoUserAgent() + " Last",
+			ExpectedUserAgent: "APN/1.0 partner/1.0 first/1.2.3 second/1.0.2 " + awsSdkGoUserAgent() + " Last/9.0.0",
 		},
 		"User-Agent Products": {
 			Config: &config.Config{

--- a/internal/test/user_agent.go
+++ b/internal/test/user_agent.go
@@ -20,6 +20,8 @@ type UserAgentTestCase struct {
 }
 
 func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUserAgentProducts func(t *testing.T, testCase UserAgentTestCase)) {
+	t.Helper()
+
 	testCases := map[string]UserAgentTestCase{
 		"standard User-Agent": {
 			Config: &config.Config{
@@ -29,17 +31,43 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: awsSdkGoUserAgent(),
 		},
-		"customized User-Agent TF_APPEND_USER_AGENT": {
+
+		"customized User-Agent TF_APPEND_USER_AGENT product": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
 				Region:    "us-east-1",
 				SecretKey: servicemocks.MockStaticSecretKey,
 			},
 			EnvironmentVariables: map[string]string{
-				constants.AppendUserAgentEnvVar: "Last/9.0.0",
+				constants.AppendUserAgentEnvVar: "Env",
 			},
-			ExpectedUserAgent: awsSdkGoUserAgent() + " Last/9.0.0",
+			ExpectedUserAgent: awsSdkGoUserAgent() + " Env",
 		},
+
+		"customized User-Agent TF_APPEND_USER_AGENT product version": {
+			Config: &config.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				constants.AppendUserAgentEnvVar: "Env/1.2",
+			},
+			ExpectedUserAgent: awsSdkGoUserAgent() + " Env/1.2",
+		},
+
+		"customized User-Agent TF_APPEND_USER_AGENT multi product": {
+			Config: &config.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				constants.AppendUserAgentEnvVar: "Env1/1.2 Env2",
+			},
+			ExpectedUserAgent: awsSdkGoUserAgent() + " Env1/1.2 Env2",
+		},
+
 		"APN User-Agent Products": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -62,6 +90,7 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: "APN/1.0 partner/1.0 first/1.2.3 second/1.0.2 (a comment) " + awsSdkGoUserAgent(),
 		},
+
 		"APN User-Agent Products and TF_APPEND_USER_AGENT": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -86,6 +115,7 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: "APN/1.0 partner/1.0 first/1.2.3 second/1.0.2 " + awsSdkGoUserAgent() + " Last/9.0.0",
 		},
+
 		"User-Agent Products": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -105,6 +135,7 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: awsSdkGoUserAgent() + " first/1.2.3 second/1.0.2 (a comment)",
 		},
+
 		"APN and User-Agent Products": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -137,6 +168,7 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: "APN/1.0 partner/1.0 first/1.2.3 second/1.0.2 (a comment) " + awsSdkGoUserAgent() + " third/4.5.6 fourth/2.1",
 		},
+
 		"context": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,
@@ -156,6 +188,7 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			},
 			ExpectedUserAgent: awsSdkGoUserAgent() + " first/1.2.3 second/1.0.2 (a comment)",
 		},
+
 		"User-Agent Products and context": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,

--- a/internal/test/user_agent.go
+++ b/internal/test/user_agent.go
@@ -68,6 +68,18 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 			ExpectedUserAgent: awsSdkGoUserAgent() + " Env1/1.2 Env2",
 		},
 
+		"customized User-Agent TF_APPEND_USER_AGENT with comment": {
+			Config: &config.Config{
+				AccessKey: servicemocks.MockStaticAccessKey,
+				Region:    "us-east-1",
+				SecretKey: servicemocks.MockStaticSecretKey,
+			},
+			EnvironmentVariables: map[string]string{
+				constants.AppendUserAgentEnvVar: "Env1/1.2 (comment) Env2",
+			},
+			ExpectedUserAgent: awsSdkGoUserAgent() + " Env1/1.2 (comment) Env2",
+		},
+
 		"APN User-Agent Products": {
 			Config: &config.Config{
 				AccessKey: servicemocks.MockStaticAccessKey,

--- a/user_agent.go
+++ b/user_agent.go
@@ -39,13 +39,13 @@ func prependUserAgentHeader(request *smithyhttp.Request, value string) {
 	request.Header["User-Agent"] = append(request.Header["User-Agent"][:0], current)
 }
 
-func withUserAgentAppender(foo UserAgentProducts) func(*middleware.Stack) error {
+func withUserAgentAppender(foo string) func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
 		return stack.Build.Add(userAgentMiddleware(foo), middleware.After)
 	}
 }
 
-func userAgentMiddleware(foo UserAgentProducts) middleware.BuildMiddleware {
+func userAgentMiddleware(foo string) middleware.BuildMiddleware {
 	return middleware.BuildMiddlewareFunc("tfUserAgentAppender",
 		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (middleware.BuildOutput, middleware.Metadata, error) {
 			request, ok := in.Request.(*smithyhttp.Request)
@@ -53,7 +53,7 @@ func userAgentMiddleware(foo UserAgentProducts) middleware.BuildMiddleware {
 				return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("unknown request type %T", in.Request)
 			}
 
-			appendUserAgentHeader(request, foo.BuildUserAgentString())
+			appendUserAgentHeader(request, foo)
 
 			return next.HandleBuild(ctx, in)
 		},

--- a/user_agent.go
+++ b/user_agent.go
@@ -39,13 +39,13 @@ func prependUserAgentHeader(request *smithyhttp.Request, value string) {
 	request.Header["User-Agent"] = append(request.Header["User-Agent"][:0], current)
 }
 
-func withUserAgentAppender(foo string) func(*middleware.Stack) error {
+func withUserAgentAppender(ua string) func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
-		return stack.Build.Add(userAgentMiddleware(foo), middleware.After)
+		return stack.Build.Add(userAgentMiddleware(ua), middleware.After)
 	}
 }
 
-func userAgentMiddleware(foo string) middleware.BuildMiddleware {
+func userAgentMiddleware(ua string) middleware.BuildMiddleware {
 	return middleware.BuildMiddlewareFunc("tfUserAgentAppender",
 		func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (middleware.BuildOutput, middleware.Metadata, error) {
 			request, ok := in.Request.(*smithyhttp.Request)
@@ -53,7 +53,7 @@ func userAgentMiddleware(foo string) middleware.BuildMiddleware {
 				return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("unknown request type %T", in.Request)
 			}
 
-			appendUserAgentHeader(request, foo)
+			appendUserAgentHeader(request, ua)
 
 			return next.HandleBuild(ctx, in)
 		},


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: #0000 <!--- Pull Requests should have an associated issue or may be closed --->

Please briefly describe the changes proposed in this pull request.

----

Since version 1.19 of `aws-sdk-go-v2`, some special characters in User-Agent strings are being escaped (https://github.com/aws/aws-sdk-go-v2/pull/2154).  In `aws-sdk-go-base`, the handling of User-Agent strings has been updated in https://github.com/hashicorp/aws-sdk-go-base/pull/554, but as for `TF_APPEND_USER_AGENT` it's still appended with the `aws-sdk-go-v2` implementation.  This has led to a regression in our usage of `terraform-provider-aws` because of the presence of a `/` character in our `TF_APPEND_USER_AGENT`.  While it might sound like an edge case, but I'd appreciate it if `TF_APPEND_USER_AGENT` is appended as it used to be!
