### PR TITLE
Add configurable `retry.BackoffDelayer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 <!-- markdownlint-disable single-title -->
 # v2.0.0 (Unreleased)
 
+# v2.0.0-beta.53 (2024-05-09)
+
 BUG FIXES
 
 * Updates dependencies.
 
 ENHANCEMENTS
 
-* Adds `Backoff` parameter to configure the backoff strategy the retryer will use to determine the delay between retry attempts
+* Adds `Backoff` parameter to configure the backoff strategy the retryer will use to determine the delay between retry attempts ([#1045](https://github.com/hashicorp/aws-sdk-go-base/pull/1045))
 
 # v2.0.0-beta.52 (2024-04-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 <!-- markdownlint-disable single-title -->
 # v2.0.0 (Unreleased)
 
+BUG FIXES
+
+* Updates dependencies.
+
+ENHANCEMENTS
+
+* Adds `Backoff` parameter to configure the backoff strategy the retryer will use to determine the delay between retry attempts
+
 # v2.0.0-beta.52 (2024-04-11)
 
 BUG FIXES

--- a/aws_config.go
+++ b/aws_config.go
@@ -202,6 +202,12 @@ func resolveRetryer(ctx context.Context, c *Config, awsConfig *aws.Config) {
 
 	var standardOptions []func(*retry.StandardOptions)
 
+	if backoff := c.Backoff; backoff != nil {
+		standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
+			so.Backoff = backoff
+		})
+	}
+
 	if v, found, _ := awsconfig.GetRetryMaxAttempts(ctx, awsConfig.ConfigSources); found && v != 0 {
 		standardOptions = append(standardOptions, func(so *retry.StandardOptions) {
 			so.MaxAttempts = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/hashicorp/aws-sdk-go-base/v2/diag"
@@ -34,6 +35,7 @@ type Config struct {
 	APNInfo                        *APNInfo
 	AssumeRole                     *AssumeRole
 	AssumeRoleWithWebIdentity      *AssumeRoleWithWebIdentity
+	Backoff                        retry.BackoffDelayer
 	CallerDocumentationURL         string
 	CallerName                     string
 	CustomCABundle                 string

--- a/v2/awsv1shim/go.mod
+++ b/v2/awsv1shim/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.7
 	github.com/google/go-cmp v0.6.0
-	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.52
+	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.53
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.51.0


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes https://github.com/hashicorp/aws-sdk-go-base/issues/1044.

Adds the `Backoff` field to the `Config` structure to allow a configurable backoff strategy.

```console
% go test ./...
?   	github.com/hashicorp/aws-sdk-go-base/v2/configtesting	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/awsconfig	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/constants	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/errs	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/slices	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/internal/test	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/mockdata	[no test files]
?   	github.com/hashicorp/aws-sdk-go-base/v2/servicemocks	[no test files]
ok  	github.com/hashicorp/aws-sdk-go-base/v2	6.593s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/diag	1.001s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/config	0.815s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/endpoints	1.127s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/internal/expand	1.346s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/logging	1.443s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/tfawserr	1.197s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/useragent	1.233s
ok  	github.com/hashicorp/aws-sdk-go-base/v2/validation	1.291s
```
