### PR TITLE
Group dependabot directories into single rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/tools"
+      - "/v2/awsv1shim"
     groups:
       aws-sdk-go:
         patterns:
@@ -19,29 +22,6 @@ updates:
         patterns:
           - "go.opentelemetry.io/otel"
           - "go.opentelemetry.io/contrib/*"
-    ignore:
-      - dependency-name: "golang.org/x/tools"
-      - dependency-name: "google.golang.org/grpc"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/v2/awsv1shim"
-    groups:
-      open-telemetry:
-        patterns:
-          - "go.opentelemetry.io/otel"
-          - "go.opentelemetry.io/contrib/*"
-    ignore:
-      - dependency-name: "github.com/aws/aws-sdk-go-v2"
-      - dependency-name: "github.com/aws/aws-sdk-go-v2/*"
-      - dependency-name: "golang.org/x/tools"
-      - dependency-name: "google.golang.org/grpc"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "gomod"
-    directory: "/tools"
     ignore:
       - dependency-name: "golang.org/x/tools"
       - dependency-name: "google.golang.org/grpc"


### PR DESCRIPTION
Groups the three module directories into a single dependabot rule. Hopefully this will create a single PR, but it's not clear from the GH documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories