### PR TITLE
Upgrade minimum Go version to 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In order to assist with migrating large code bases using the AWS SDK for Go v1, 
 
 ## Requirements
 
-* [Go](https://golang.org/doc/install) 1.21 or higher
+* [Go](https://golang.org/doc/install) 1.23 or higher
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/aws-sdk-go-base/v2
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.2

--- a/go.work
+++ b/go.work
@@ -1,6 +1,4 @@
-go 1.23.0
-
-toolchain go1.23.6
+go 1.23.6
 
 use (
 	.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/aws-sdk-go-base/tools
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.23.6
 
 require (
 	github.com/golangci/golangci-lint v1.64.5

--- a/v2/awsv1shim/go.mod
+++ b/v2/awsv1shim/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2
 
-go 1.22.0
-
-toolchain go1.22.7
+go 1.23.6
 
 require (
 	github.com/aws/aws-sdk-go v1.55.6


### PR DESCRIPTION
Updates minimum supported Go version to 1.23, as 1.24 has been released