### PR TITLE
Fixes linting config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
   exclude-rules:
     - path: configtesting

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,10 +24,10 @@ issues:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dogsled
     - errcheck
     - errname
-    - exportloopref
     - goconst
     - gofmt
     - gosimple
@@ -44,6 +44,8 @@ linters:
     - whitespace
 
 linters-settings:
+  copyloopvar:
+    check-alias: true
   goconst:
     ignore-tests: true
   mnd:

--- a/aws_config_test.go
+++ b/aws_config_test.go
@@ -984,9 +984,6 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 	}
 
 	for testName, testCase := range testCases {
-		testName := testName
-		testCase := testCase
-
 		if testCase.ValidateDiags == nil {
 			testCase.ValidateDiags = test.ExpectNoDiags
 		}
@@ -1341,8 +1338,6 @@ region = us-west-2
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -1468,8 +1463,6 @@ max_attempts = 10
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -1601,8 +1594,6 @@ retry_mode = adaptive
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -1826,8 +1817,6 @@ use_fips_endpoint = true
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -1957,8 +1946,6 @@ func TestEC2MetadataServiceClientEnableState(t *testing.T) {
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -2144,8 +2131,6 @@ ec2_metadata_service_endpoint = https://127.1.1.1:1111
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -2269,8 +2254,6 @@ ec2_metadata_service_endpoint_mode = IPv4
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -2394,8 +2377,6 @@ func TestCustomCABundle(t *testing.T) {
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -2670,8 +2651,6 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -2944,8 +2923,6 @@ web_identity_token_file = no-such-file
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := context.Background()
 
@@ -3307,8 +3284,6 @@ endpoint_url = %[2]s
 	}
 
 	for name, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -3548,19 +3523,17 @@ func TestGetAwsConfigWithAccountIDAndPartition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		tc := testCase
-
-		t.Run(tc.desc, func(t *testing.T) {
-			ts := servicemocks.MockAwsApiServer("STS", tc.mockStsEndpoints)
+		t.Run(testCase.desc, func(t *testing.T) {
+			ts := servicemocks.MockAwsApiServer("STS", testCase.mockStsEndpoints)
 			defer ts.Close()
-			tc.config.StsEndpoint = ts.URL
+			testCase.config.StsEndpoint = ts.URL
 
-			ctx, awsConfig, diags := GetAwsConfig(context.Background(), tc.config)
+			ctx, awsConfig, diags := GetAwsConfig(context.Background(), testCase.config)
 			if diags.HasError() {
 				t.Fatalf("error in GetAwsConfig(): %v", diags)
 			}
 
-			acctID, part, diags := GetAwsAccountIDAndPartition(ctx, awsConfig, tc.config)
+			acctID, part, diags := GetAwsAccountIDAndPartition(ctx, awsConfig, testCase.config)
 
 			if diff := cmp.Diff(diags, testCase.ExpectedDiags); diff != "" {
 				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
@@ -3569,12 +3542,12 @@ func TestGetAwsConfigWithAccountIDAndPartition(t *testing.T) {
 				return
 			}
 
-			if acctID != tc.expectedAcctID {
-				t.Errorf("expected account ID (%s), got: %s", tc.expectedAcctID, acctID)
+			if acctID != testCase.expectedAcctID {
+				t.Errorf("expected account ID (%s), got: %s", testCase.expectedAcctID, acctID)
 			}
 
-			if part != tc.expectedPartition {
-				t.Errorf("expected partition (%s), got: %s", tc.expectedPartition, part)
+			if part != testCase.expectedPartition {
+				t.Errorf("expected partition (%s), got: %s", testCase.expectedPartition, part)
 			}
 		})
 	}
@@ -3812,8 +3785,6 @@ func TestRetryHandlers(t *testing.T) {
 	}
 
 	for name, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 

--- a/awsauth_test.go
+++ b/awsauth_test.go
@@ -112,8 +112,6 @@ func TestGetAccountIDAndPartition(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -219,8 +217,6 @@ func TestGetAccountIDAndPartitionFromIAMGetUser(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -278,8 +274,6 @@ func TestGetAccountIDAndPartitionFromIAMListRoles(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -373,8 +367,6 @@ func TestGetAccountIDAndPartitionFromSTSGetCallerIdentity(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -434,8 +426,6 @@ func TestAWSParseAccountIDAndPartitionFromARN(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.InputARN, func(t *testing.T) {
 			accountID, partition, err := parseAccountIDAndPartitionFromARN(testCase.InputARN)
 			if err != nil && testCase.ErrCount == 0 {

--- a/configtesting/config.go
+++ b/configtesting/config.go
@@ -116,8 +116,6 @@ sso_registration_scopes = sso:account:access
 	}
 
 	for name, tc := range testCases {
-		tc := tc
-
 		t.Run(name, func(t *testing.T) {
 			caseDriver := driver.TestCase()
 
@@ -223,8 +221,6 @@ region = us-east-1
 	}
 
 	for name, tc := range testCases {
-		tc := tc
-
 		t.Run(name, func(t *testing.T) {
 			caseDriver := driver.TestCase()
 

--- a/configtesting/file_parsing.go
+++ b/configtesting/file_parsing.go
@@ -129,8 +129,6 @@ sso_start_url = https://d-123456789a.awsapps.com/start#
 	}
 
 	for name, tc := range testcases {
-		tc := tc
-
 		t.Run(name, func(t *testing.T) {
 			ctx := context.TODO()
 

--- a/diag/diagnostics_test.go
+++ b/diag/diagnostics_test.go
@@ -55,7 +55,6 @@ func TestDiagnosticsAddError(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -113,7 +112,6 @@ func TestDiagnosticsAddWarning(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -203,7 +201,6 @@ func TestDiagnosticsAppend(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -272,7 +269,6 @@ func TestDiagnosticsContains(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -380,8 +376,6 @@ func TestDiagnosticsEqual(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -422,7 +416,6 @@ func TestDiagnosticsHasError(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -467,7 +460,6 @@ func TestDiagnosticsErrorsCount(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -512,7 +504,6 @@ func TestDiagnosticsWarningsCount(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -559,7 +550,6 @@ func TestDiagnosticsErrors(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -606,7 +596,6 @@ func TestDiagnosticsWarnings(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/diag/error_diagnostic_test.go
+++ b/diag/error_diagnostic_test.go
@@ -45,7 +45,6 @@ func TestErrorDiagnosticEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/diag/warning_diagnostic_test.go
+++ b/diag/warning_diagnostic_test.go
@@ -45,7 +45,6 @@ func TestWarningDiagnosticEqual(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -30,8 +30,6 @@ func TestIsCannotAssumeRoleError(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsCannotAssumeRoleError(testCase.Diag)
 
@@ -63,8 +61,6 @@ func TestIsNoValidCredentialSourcesError(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := IsNoValidCredentialSourcesError(testCase.Diag)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -203,8 +203,6 @@ func TestValidateProxyConfig(t *testing.T) {
 	}
 
 	for name, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 

--- a/internal/test/http_client.go
+++ b/internal/test/http_client.go
@@ -537,8 +537,6 @@ func HTTPClientConfigurationTest_proxy(t *testing.T, getter TransportGetter) {
 	}
 
 	for name, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 

--- a/internal/test/user_agent.go
+++ b/internal/test/user_agent.go
@@ -233,8 +233,6 @@ func TestUserAgentProducts(t *testing.T, awsSdkGoUserAgent func() string, testUs
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 

--- a/logging/aws_test.go
+++ b/logging/aws_test.go
@@ -88,7 +88,6 @@ func TestMaskAWSSensitiveValues(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tfawserr/awserr_test.go
+++ b/tfawserr/awserr_test.go
@@ -82,8 +82,6 @@ func TestErrCodeEquals(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
 
@@ -134,8 +132,6 @@ func TestErrCodeContains(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			got := ErrCodeContains(testCase.Err, testCase.Code)
 
@@ -267,8 +263,6 @@ func TestErrMessageContains(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			got := ErrMessageContains(testCase.Err, testCase.Code, testCase.Message)
 
@@ -327,8 +321,6 @@ func TestErrHTTPStatusCodeEquals(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(name, func(t *testing.T) {
 			got := ErrHTTPStatusCodeEquals(testCase.Err, testCase.Codes...)
 

--- a/v2/awsv1shim/session_test.go
+++ b/v2/awsv1shim/session_test.go
@@ -61,28 +61,26 @@ func TestGetSessionOptions(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		tc := testCase
-
-		t.Run(tc.desc, func(t *testing.T) {
+		t.Run(testCase.desc, func(t *testing.T) {
 			ctx := test.Context(t)
 
-			tc.config.SkipCredsValidation = true
+			testCase.config.SkipCredsValidation = true
 
-			ctx, awsConfig, diags := awsbase.GetAwsConfig(ctx, tc.config)
+			ctx, awsConfig, diags := awsbase.GetAwsConfig(ctx, testCase.config)
 			if diags.HasError() {
 				t.Fatalf("GetAwsConfig() resulted in an error %v", diags)
 			}
 
-			opts, err := getSessionOptions(ctx, &awsConfig, tc.config)
-			if err != nil && tc.expectError == false {
+			opts, err := getSessionOptions(ctx, &awsConfig, testCase.config)
+			if err != nil && testCase.expectError == false {
 				t.Fatalf("getSessionOptions() resulted in an error %s", err)
 			}
 
-			if opts == nil && tc.expectError == false {
+			if opts == nil && testCase.expectError == false {
 				t.Error("getSessionOptions() resulted in a nil set of options")
 			}
 
-			if err == nil && tc.expectError == true {
+			if err == nil && testCase.expectError == true {
 				t.Fatal("Expected error not returned by getSessionOptions()")
 			}
 		})
@@ -1031,9 +1029,6 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 	}
 
 	for testName, testCase := range testCases {
-		testName := testName
-		testCase := testCase
-
 		if testCase.ValidateDiags == nil {
 			testCase.ValidateDiags = test.ExpectNoDiags
 		}
@@ -1287,8 +1282,6 @@ max_attempts = 10
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -1411,8 +1404,6 @@ func TestRetryMode(t *testing.T) {
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
@@ -1571,8 +1562,6 @@ use_fips_endpoint = true
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -1741,8 +1730,6 @@ func TestCustomCABundle(t *testing.T) {
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -2002,8 +1989,6 @@ aws_secret_access_key = SharedConfigurationSourceSecretKey
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -2292,8 +2277,6 @@ web_identity_token_file = no-such-file
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -2497,8 +2480,6 @@ func TestSessionRetryHandlers(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(testcase.Description, func(t *testing.T) {
 			ctx := test.Context(t)
 
@@ -2688,8 +2669,6 @@ s3_us_east_1_regional_endpoint = legacy
 	}
 
 	for testName, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testName, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 

--- a/v2/awsv1shim/tfawserr/awserr_test.go
+++ b/v2/awsv1shim/tfawserr/awserr_test.go
@@ -227,8 +227,6 @@ func TestErrMessageAndOrigErrContain(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := ErrMessageAndOrigErrContain(testCase.Err, testCase.Code, testCase.Message, testCase.ExtendedMessage)
 
@@ -328,8 +326,6 @@ func TestErrCodeEquals(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := ErrCodeEquals(testCase.Err, testCase.Codes...)
 
@@ -421,8 +417,6 @@ func TestErrCodeContains(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := ErrCodeContains(testCase.Err, testCase.Code)
 
@@ -594,8 +588,6 @@ func TestErrMessageContains(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := ErrMessageContains(testCase.Err, testCase.Code, testCase.Message)
 
@@ -665,8 +657,6 @@ func TestErrStatusCodeEquals(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Name, func(t *testing.T) {
 			got := ErrStatusCodeEquals(testCase.Err, testCase.StatusCode)
 

--- a/validation/region_test.go
+++ b/validation/region_test.go
@@ -35,8 +35,6 @@ func TestSupportedRegion(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.Region, func(t *testing.T) {
 			err := SupportedRegion(testCase.Region)
 			if err != nil && !testCase.ExpectError {


### PR DESCRIPTION
Replaces deprecated linter `exportloopref` with `copyloopvar` and fixes violations