### PR TITLE
Add explicit `permissions` block to workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,9 @@
 name: Pull Request Checks
 on: [pull_request]
 
+permissions:
+  contents: read # Needed for checkout
+
 jobs:
   go_mod:
     name: go mod


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

This PR adds explicit an `permissions` block to our workflow to make it least privileged. This is intended to ensure the workflows keeps functioning after our recent organization default permissions scopes were updated.

I took the opportunity to add a comment to indicate why this particular permission configuration is needed.