### PR TITLE
Logging: Reduce allocations when logging request and response bodies

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -230,10 +230,10 @@ func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response
 		return err
 	}
 
+	*attrs = append(*attrs, attribute.String("http.response.body", body))
+
 	// Restore the full body for the SDK deserialiser.
 	resp.Body = io.NopCloser(io.MultiReader(&original, resp.Body))
-
-	*attrs = append(*attrs, attribute.String("http.response.body", body))
 
 	return nil
 }

--- a/logger.go
+++ b/logger.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/textproto"
 	"strings"
 	"time"
 
@@ -206,20 +205,18 @@ var _ logging.ResponseBodyLogger = &defaultResponseBodyLogger{}
 type defaultResponseBodyLogger struct{}
 
 func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response, attrs *[]attribute.KeyValue) error {
-	content, err := io.ReadAll(resp.Body)
+	var original bytes.Buffer
+	tee := io.TeeReader(resp.Body, &original)
+
+	scanner := bufio.NewScanner(tee)
+
+	body, err := logging.ReadTruncatedBodyNew(scanner, logging.MaxResponseBodyLen)
 	if err != nil {
 		return err
 	}
 
-	// Restore the body reader
-	resp.Body = io.NopCloser(bytes.NewBuffer(content))
-
-	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(content)))
-
-	body, err := logging.ReadTruncatedBody(reader, logging.MaxResponseBodyLen)
-	if err != nil {
-		return err
-	}
+	// Restore the full body for the SDK deserialiser.
+	resp.Body = io.NopCloser(io.MultiReader(&original, resp.Body))
 
 	*attrs = append(*attrs, attribute.String("http.response.body", body))
 

--- a/logger.go
+++ b/logger.go
@@ -114,6 +114,7 @@ func (r *requestResponseLogger) HandleDeserialize(ctx context.Context, in middle
 	out middleware.DeserializeOutput, metadata middleware.Metadata, err error,
 ) {
 	logger := logging.RetrieveLogger(ctx)
+	isDebug := logger.IsDebug(ctx)
 
 	region := awsmiddleware.GetRegion(ctx)
 
@@ -131,12 +132,10 @@ func (r *requestResponseLogger) HandleDeserialize(ctx context.Context, in middle
 
 	rc := smithyRequest.Build(ctx)
 
-	if logger.IsDebug(ctx) {
-		requestFields, err := logging.DecomposeHTTPRequest(ctx, rc)
-		if err != nil {
-			return out, metadata, fmt.Errorf("decomposing request: %w", err)
+	if isDebug {
+		if err := r.logRequest(ctx, logger, rc); err != nil {
+			return out, metadata, err
 		}
-		logger.Debug(ctx, "HTTP Request Sent", requestFields)
 	}
 
 	smithyRequest, err = smithyRequest.SetStream(rc.Body)
@@ -151,20 +150,36 @@ func (r *requestResponseLogger) HandleDeserialize(ctx context.Context, in middle
 
 	elapsed := time.Since(start)
 
-	if err == nil && logger.IsDebug(ctx) {
-		smithyResponse, ok := out.RawResponse.(*smithyhttp.Response)
-		if !ok {
-			return out, metadata, fmt.Errorf("unknown response type: %T", out.RawResponse)
+	if err == nil && isDebug {
+		if err = r.logResponse(ctx, logger, out.RawResponse, elapsed); err != nil {
+			return out, metadata, err
 		}
-
-		responseFields, err := decomposeHTTPResponse(ctx, smithyResponse.Response, elapsed)
-		if err != nil {
-			return out, metadata, fmt.Errorf("decomposing response: %w", err)
-		}
-		logger.Debug(ctx, "HTTP Response Received", responseFields)
 	}
 
 	return out, metadata, err
+}
+
+func (r *requestResponseLogger) logRequest(ctx context.Context, logger logging.Logger, rc *http.Request) error {
+	requestFields, err := logging.DecomposeHTTPRequest(ctx, rc)
+	if err != nil {
+		return fmt.Errorf("decomposing request: %w", err)
+	}
+	logger.Debug(ctx, "HTTP Request Sent", requestFields)
+	return nil
+}
+
+func (r *requestResponseLogger) logResponse(ctx context.Context, logger logging.Logger, rawResponse any, elapsed time.Duration) error {
+	smithyResponse, ok := rawResponse.(*smithyhttp.Response)
+	if !ok {
+		return fmt.Errorf("unknown response type: %T", rawResponse)
+	}
+
+	responseFields, err := decomposeHTTPResponse(ctx, smithyResponse.Response, elapsed)
+	if err != nil {
+		return fmt.Errorf("decomposing response: %w", err)
+	}
+	logger.Debug(ctx, "HTTP Response Received", responseFields)
+	return nil
 }
 
 func decomposeHTTPResponse(ctx context.Context, resp *http.Response, elapsed time.Duration) (map[string]any, error) {

--- a/logger.go
+++ b/logger.go
@@ -220,8 +220,10 @@ var _ logging.ResponseBodyLogger = &defaultResponseBodyLogger{}
 type defaultResponseBodyLogger struct{}
 
 func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response, attrs *[]attribute.KeyValue) error {
-	var original bytes.Buffer
-	tee := io.TeeReader(resp.Body, &original)
+	original := logging.BufferPool.Get()
+	defer logging.BufferPool.Put(original)
+
+	tee := io.TeeReader(resp.Body, original)
 
 	scanner := bufio.NewScanner(tee)
 
@@ -233,7 +235,7 @@ func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response
 	*attrs = append(*attrs, attribute.String("http.response.body", body))
 
 	// Restore the full body for the SDK deserialiser.
-	resp.Body = io.NopCloser(io.MultiReader(&original, resp.Body))
+	resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(original.Bytes()), resp.Body))
 
 	return nil
 }

--- a/logger.go
+++ b/logger.go
@@ -210,7 +210,7 @@ func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response
 
 	scanner := bufio.NewScanner(tee)
 
-	body, err := logging.ReadTruncatedBodyNew(scanner, logging.MaxResponseBodyLen)
+	body, err := logging.ReadTruncatedBody(scanner, logging.MaxResponseBodyLen)
 	if err != nil {
 		return err
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -99,9 +99,12 @@ func BenchmarkResponseBodyLogger(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
+		b.StopTimer()
 		resp := &http.Response{
 			Body: io.NopCloser(strings.NewReader(bodyStr)),
 		}
+		b.StartTimer()
+
 		var attrs []attribute.KeyValue
 		if err := logger.Log(b.Context(), resp, &attrs); err != nil {
 			b.Fatal(err)

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,110 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package awsbase
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestDefaultResponseBodyLogger(t *testing.T) {
+	t.Parallel()
+
+	// Build a large body well over MaxResponseBodyLen (4096 bytes).
+	// Each line is "abcdefgh\n" (9 bytes). 12,000 lines = 108,000 bytes.
+	var largeBodyBuilder strings.Builder
+	for range 12_000 {
+		largeBodyBuilder.WriteString("abcdefgh\n")
+	}
+	largeBody := largeBodyBuilder.String()
+
+	// ReadTruncatedBody writes lines until builder.Len() >= 4096, then appends
+	// [truncated...].  9-byte lines: 456 lines = 4104 bytes ≥ 4096.
+	var largeTruncatedBuilder strings.Builder
+	for range 456 {
+		largeTruncatedBuilder.WriteString("abcdefgh\n")
+	}
+	largeTruncatedBuilder.WriteString("[truncated...]")
+	largeTruncated := largeTruncatedBuilder.String()
+
+	tests := map[string]struct {
+		responseBody    string
+		expectedLogBody string
+	}{
+		"small_body": {
+			responseBody:    "Action=ListUsers&Version=2010-05-08\n",
+			expectedLogBody: "Action=ListUsers&Version=2010-05-08\n",
+		},
+		"large_body": {
+			responseBody:    largeBody,
+			expectedLogBody: largeTruncated,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &http.Response{
+				Body: io.NopCloser(strings.NewReader(tc.responseBody)),
+			}
+
+			logger := &defaultResponseBodyLogger{}
+			var attrs []attribute.KeyValue
+
+			if err := logger.Log(t.Context(), resp, &attrs); err != nil {
+				t.Fatalf("Log() error = %v", err)
+			}
+
+			// Check the logged body attribute.
+			var gotBody string
+			for _, kv := range attrs {
+				if string(kv.Key) == "http.response.body" {
+					gotBody = kv.Value.AsString()
+					break
+				}
+			}
+			if gotBody != tc.expectedLogBody {
+				t.Errorf("http.response.body:\n got: %q\nwant: %q", gotBody, tc.expectedLogBody)
+			}
+
+			// Check that resp.Body is still fully readable (body restored).
+			remaining, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("reading resp.Body after Log: %v", err)
+			}
+			if string(remaining) != tc.responseBody {
+				t.Errorf("resp.Body after Log:\n got: %q\nwant: %q", string(remaining), tc.responseBody)
+			}
+		})
+	}
+}
+
+func BenchmarkResponseBodyLogger(b *testing.B) {
+	// Use a large body (50,000 lines = ~450 KB) to show the benefit of early
+	// truncation: the scanner stops after ~456 lines but the old io.ReadAll
+	// had to buffer the entire body.
+	var bodyBuilder strings.Builder
+	for range 50_000 {
+		bodyBuilder.WriteString("abcdefgh\n")
+	}
+	bodyStr := bodyBuilder.String()
+
+	logger := &defaultResponseBodyLogger{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		resp := &http.Response{
+			Body: io.NopCloser(strings.NewReader(bodyStr)),
+		}
+		var attrs []attribute.KeyValue
+		if err := logger.Log(b.Context(), resp, &attrs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/logging/buffer_pool.go
+++ b/logging/buffer_pool.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"bytes"
+	"sync"
+)
+
+var BufferPool = newBufferPool()
+
+type bufferPool struct {
+	sync.Pool
+}
+
+func newBufferPool() *bufferPool {
+	return &bufferPool{
+		Pool: sync.Pool{
+			New: func() any {
+				return bytes.NewBuffer(make([]byte, 0, MaxResponseBodyLen))
+			},
+		},
+	}
+}
+
+func (p *bufferPool) Get() *bytes.Buffer {
+	return p.Pool.Get().(*bytes.Buffer)
+}
+
+func (p *bufferPool) Put(v *bytes.Buffer) {
+	v.Reset()
+	p.Pool.Put(v)
+}

--- a/logging/http.go
+++ b/logging/http.go
@@ -7,11 +7,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/textproto"
 	"regexp"
 	"strconv"
 	"strings"
@@ -125,7 +123,7 @@ func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, a
 
 	scanner := bufio.NewScanner(tee)
 
-	body, err := ReadTruncatedBodyNew(scanner, maxRequestBodyLen)
+	body, err := ReadTruncatedBody(scanner, maxRequestBodyLen)
 	if err != nil {
 		return err
 	}
@@ -317,30 +315,7 @@ func cleanUpHeaderAttributes(attrs []attribute.KeyValue) []attribute.KeyValue {
 	})
 }
 
-func ReadTruncatedBody(reader *textproto.Reader, len int) (string, error) {
-	var builder strings.Builder
-	for {
-		line, err := reader.ReadLine()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return "", err
-		}
-		fmt.Fprintln(&builder, line)
-		if builder.Len() >= len {
-			fmt.Fprint(&builder, "[truncated...]")
-			break
-		}
-	}
-
-	body := builder.String()
-	body = MaskAWSSensitiveValues(body)
-
-	return body, nil
-}
-
-func ReadTruncatedBodyNew(scanner *bufio.Scanner, len int) (string, error) {
+func ReadTruncatedBody(scanner *bufio.Scanner, len int) (string, error) {
 	var builder strings.Builder
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/logging/http.go
+++ b/logging/http.go
@@ -118,8 +118,10 @@ func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, a
 		return nil
 	}
 
-	var original bytes.Buffer
-	tee := io.TeeReader(req.Body, &original)
+	original := BufferPool.Get()
+	defer BufferPool.Put(original)
+
+	tee := io.TeeReader(req.Body, original)
 
 	scanner := bufio.NewScanner(tee)
 
@@ -131,7 +133,7 @@ func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, a
 	*attrs = append(*attrs, attribute.String("http.request.body", body))
 
 	// Restore the full body for the SDK serialiser.
-	req.Body = io.NopCloser(io.MultiReader(&original, req.Body))
+	req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(original.Bytes()), req.Body))
 
 	return nil
 }

--- a/logging/http.go
+++ b/logging/http.go
@@ -318,10 +318,10 @@ func cleanUpHeaderAttributes(attrs []attribute.KeyValue) []attribute.KeyValue {
 func ReadTruncatedBody(scanner *bufio.Scanner, len int) (string, error) {
 	var builder strings.Builder
 	for scanner.Scan() {
-		line := scanner.Text()
-		fmt.Fprintln(&builder, line)
+		builder.Write(scanner.Bytes())
+		builder.WriteByte('\n')
 		if builder.Len() >= len {
-			fmt.Fprint(&builder, "[truncated...]")
+			builder.WriteString("[truncated...]")
 			break
 		}
 	}

--- a/logging/http.go
+++ b/logging/http.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/textproto"
 	"regexp"
 	"strconv"
@@ -116,27 +115,25 @@ var _ RequestBodyLogger = &defaultRequestBodyLogger{}
 type defaultRequestBodyLogger struct{}
 
 func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, attrs *[]attribute.KeyValue) error {
-	reqBytes, err := httputil.DumpRequestOut(req, true)
-	if err != nil {
-		return err
+	if req.Body == nil || req.Body == http.NoBody {
+		*attrs = append(*attrs, attribute.String("http.request.body", ""))
+		return nil
 	}
 
-	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(reqBytes)))
+	var original bytes.Buffer
+	tee := io.TeeReader(req.Body, &original)
 
-	if _, err = reader.ReadLine(); err != nil {
-		return err
-	}
+	scanner := bufio.NewScanner(tee)
 
-	if _, err = reader.ReadMIMEHeader(); err != nil {
-		return err
-	}
-
-	body, err := ReadTruncatedBody(reader, maxRequestBodyLen)
+	body, err := ReadTruncatedBodyNew(scanner, maxRequestBodyLen)
 	if err != nil {
 		return err
 	}
 
 	*attrs = append(*attrs, attribute.String("http.request.body", body))
+
+	// Restore the full body for the SDK serialiser.
+	req.Body = io.NopCloser(io.MultiReader(&original, req.Body))
 
 	return nil
 }
@@ -335,6 +332,26 @@ func ReadTruncatedBody(reader *textproto.Reader, len int) (string, error) {
 			fmt.Fprint(&builder, "[truncated...]")
 			break
 		}
+	}
+
+	body := builder.String()
+	body = MaskAWSSensitiveValues(body)
+
+	return body, nil
+}
+
+func ReadTruncatedBodyNew(scanner *bufio.Scanner, len int) (string, error) {
+	var builder strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		fmt.Fprintln(&builder, line)
+		if builder.Len() >= len {
+			fmt.Fprint(&builder, "[truncated...]")
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
 	}
 
 	body := builder.String()

--- a/logging/http_test.go
+++ b/logging/http_test.go
@@ -13,6 +13,93 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+func TestDefaultRequestBodyLogger(t *testing.T) {
+	t.Parallel()
+
+	// Build a large body well over maxRequestBodyLen (1024 bytes).
+	// bufio.Scanner has a default buffer size of 4,096 bytes.
+	// Each line is "abcdefgh\n" (9 bytes). 12,000 lines = 108,000 bytes.
+	var largeBodyBuilder strings.Builder
+	for range 12_000 {
+		largeBodyBuilder.WriteString("abcdefgh\n")
+	}
+	largeBody := largeBodyBuilder.String()
+
+	// ReadTruncatedBody writes lines until builder.Len() >= 1024, then appends
+	// [truncated...].  9-byte lines: 114 lines = 1026 bytes ≥ 1024.
+	var largeTruncatedBuilder strings.Builder
+	for range 114 {
+		largeTruncatedBuilder.WriteString("abcdefgh\n")
+	}
+	largeTruncatedBuilder.WriteString("[truncated...]")
+	largeTruncated := largeTruncatedBuilder.String()
+
+	tests := map[string]struct {
+		requestBody     string
+		expectedLogBody string
+	}{
+		"nil_body": {
+			requestBody:     "",
+			expectedLogBody: "",
+		},
+		"small_body": {
+			requestBody:     "Action=ListUsers&Version=2010-05-08\n",
+			expectedLogBody: "Action=ListUsers&Version=2010-05-08\n",
+		},
+		"large_body": {
+			requestBody:     largeBody,
+			expectedLogBody: largeTruncated,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			expectedFullBody := tc.requestBody
+
+			req := &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+				Header: make(http.Header),
+			}
+			if tc.requestBody == "" {
+				req.Body = http.NoBody
+			} else {
+				req.Body = io.NopCloser(strings.NewReader(tc.requestBody))
+			}
+
+			logger := &defaultRequestBodyLogger{}
+			var attrs []attribute.KeyValue
+
+			if err := logger.Log(t.Context(), req, &attrs); err != nil {
+				t.Fatalf("Log() error = %v", err)
+			}
+
+			// Check the logged body attribute.
+			var gotBody string
+			for _, kv := range attrs {
+				if string(kv.Key) == "http.request.body" {
+					gotBody = kv.Value.AsString()
+					break
+				}
+			}
+			if gotBody != tc.expectedLogBody {
+				t.Errorf("http.request.body:\n got: %q\nwant: %q", gotBody, tc.expectedLogBody)
+			}
+
+			// Check that req.Body is still fully readable (body restored).
+			remaining, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("reading req.Body after Log: %v", err)
+			}
+			if string(remaining) != expectedFullBody {
+				t.Errorf("req.Body after Log:\n got: %q\nwant: %q", string(remaining), expectedFullBody)
+			}
+		})
+	}
+}
+
 func BenchmarkRequestBodyLogger(b *testing.B) {
 	// Use a body slightly larger than maxRequestBodyLen so the truncation path runs.
 	var bodyBuilder strings.Builder

--- a/logging/http_test.go
+++ b/logging/http_test.go
@@ -112,6 +112,7 @@ func BenchmarkRequestBodyLogger(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
+		b.StopTimer()
 		req := &http.Request{
 			Method: http.MethodPost,
 			URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
@@ -119,6 +120,8 @@ func BenchmarkRequestBodyLogger(b *testing.B) {
 			Body:   io.NopCloser(strings.NewReader(bodyStr)),
 		}
 		var attrs []attribute.KeyValue
+		b.StartTimer()
+
 		if err := logger.Log(b.Context(), req, &attrs); err != nil {
 			b.Fatal(err)
 		}

--- a/logging/http_test.go
+++ b/logging/http_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package logging
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func BenchmarkRequestBodyLogger(b *testing.B) {
+	// Use a body slightly larger than maxRequestBodyLen so the truncation path runs.
+	var bodyBuilder strings.Builder
+	for range 200 {
+		bodyBuilder.WriteString("abcdefgh\n")
+	}
+	bodyStr := bodyBuilder.String()
+
+	logger := &defaultRequestBodyLogger{}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		req := &http.Request{
+			Method: http.MethodPost,
+			URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/"},
+			Header: make(http.Header),
+			Body:   io.NopCloser(strings.NewReader(bodyStr)),
+		}
+		var attrs []attribute.KeyValue
+		if err := logger.Log(b.Context(), req, &attrs); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/v2/awsv1shim/logger.go
+++ b/v2/awsv1shim/logger.go
@@ -261,9 +261,10 @@ func readTruncatedBody(reader *textproto.Reader, len int) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		fmt.Fprintln(&builder, line)
+		builder.WriteString(line)
+		builder.WriteByte('\n')
 		if builder.Len() >= len {
-			fmt.Fprint(&builder, "[truncated...]")
+			builder.WriteString("[truncated...]")
 			break
 		}
 	}

--- a/v2/awsv1shim/logger.go
+++ b/v2/awsv1shim/logger.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -215,7 +216,7 @@ func decomposeResponseBody(bodyReader io.Reader) (kv attribute.KeyValue, err err
 
 	reader := textproto.NewReader(bufio.NewReader(bytes.NewReader(content)))
 
-	body, err := logging.ReadTruncatedBody(reader, logging.MaxResponseBodyLen)
+	body, err := readTruncatedBody(reader, logging.MaxResponseBodyLen)
 	if err != nil {
 		return kv, err
 	}
@@ -247,4 +248,28 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 		w.N -= int64(n)
 		return n, err
 	}
+}
+
+// readTruncatedBody is equivalent to logging.ReadTruncatedBody
+func readTruncatedBody(reader *textproto.Reader, len int) (string, error) {
+	var builder strings.Builder
+	for {
+		line, err := reader.ReadLine()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintln(&builder, line)
+		if builder.Len() >= len {
+			fmt.Fprint(&builder, "[truncated...]")
+			break
+		}
+	}
+
+	body := builder.String()
+	body = logging.MaskAWSSensitiveValues(body)
+
+	return body, nil
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: #0000 <!--- Pull Requests should have an associated issue or may be closed --->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

Reduces allocations when logging request and response bodies.

Closes #1083

Request logging changes:

```
$ benchstat req-before.txt req-after.txt

                     │ req-before.txt │        req-after.txt        │
                     │       sec/op       │   sec/op     vs base                │
RequestBodyLogger-10         37.773µ ± 2%   6.407µ ± 1%  -83.04% (p=0.000 n=10)

                     │ req-before.txt │        req-after.txt        │
                     │        B/op        │     B/op      vs base                │
RequestBodyLogger-10        46.575Ki ± 0%   8.779Ki ± 0%  -81.15% (p=0.000 n=10)

                     │ req-before.txt │        req-after.txt        │
                     │     allocs/op      │ allocs/op   vs base                │
RequestBodyLogger-10          361.00 ± 0%   18.00 ± 0%  -95.01% (p=0.000 n=10)
```

Response logging changes:

```
$ benchstat resp-before.txt resp-after.txt

                      │  resp-before.txt │       resp-after.txt        │
                      │       sec/op       │   sec/op     vs base                │
ResponseBodyLogger-10        185.35µ ± 89%   18.69µ ± 1%  -89.92% (p=0.000 n=10)

                      │  resp-before.txt │       resp-after.txt        │
                      │        B/op        │     B/op      vs base                │
ResponseBodyLogger-10       1008.15Ki ± 0%   26.81Ki ± 0%  -97.34% (p=0.000 n=10)

                      │  resp-before.txt │       resp-after.txt        │
                      │     allocs/op      │ allocs/op   vs base                │
ResponseBodyLogger-10          960.00 ± 0%   22.00 ± 0%  -97.71% (p=0.000 n=10)
```