### PR TITLE
Fixes AWS API request/response corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable single-title -->
 # v2.0.0 (Unreleased)
 
+BUG FIXES
+
+* Fixes error introduced in [#1496](https://github.com/hashicorp/aws-sdk-go-base/pull/1496) where API requests and responses were corrupted by shared memory buffers. ([#1503](https://github.com/hashicorp/aws-sdk-go-base/pull/1503))
+
 # v2.0.0-beta.74 (2026-07-28)
 
 ENHANCEMENTS

--- a/logger.go
+++ b/logger.go
@@ -5,7 +5,6 @@ package awsbase
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -220,8 +219,9 @@ var _ logging.ResponseBodyLogger = &defaultResponseBodyLogger{}
 type defaultResponseBodyLogger struct{}
 
 func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response, attrs *[]attribute.KeyValue) error {
+	// original is borrowed from the pool and teed into while scanning. Ownership
+	// is transferred to NewPooledBody, which returns it to the pool on Close.
 	original := logging.BufferPool.Get()
-	defer logging.BufferPool.Put(original)
 
 	tee := io.TeeReader(resp.Body, original)
 
@@ -229,13 +229,14 @@ func (l *defaultResponseBodyLogger) Log(ctx context.Context, resp *http.Response
 
 	body, err := logging.ReadTruncatedBody(scanner, logging.MaxResponseBodyLen)
 	if err != nil {
+		logging.BufferPool.Put(original)
 		return err
 	}
 
 	*attrs = append(*attrs, attribute.String("http.response.body", body))
 
 	// Restore the full body for the SDK deserialiser.
-	resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(original.Bytes()), resp.Body))
+	resp.Body = logging.NewPooledBody(logging.BufferPool, original, resp.Body)
 
 	return nil
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -109,5 +109,6 @@ func BenchmarkResponseBodyLogger(b *testing.B) {
 		if err := logger.Log(b.Context(), resp, &attrs); err != nil {
 			b.Fatal(err)
 		}
+		resp.Body.Close()
 	}
 }

--- a/logging/buffer_pool.go
+++ b/logging/buffer_pool.go
@@ -5,17 +5,18 @@ package logging
 
 import (
 	"bytes"
+	"io"
 	"sync"
 )
 
 var BufferPool = newBufferPool()
 
-type bufferPool struct {
+type BufferPoolType struct {
 	sync.Pool
 }
 
-func newBufferPool() *bufferPool {
-	return &bufferPool{
+func newBufferPool() *BufferPoolType {
+	return &BufferPoolType{
 		Pool: sync.Pool{
 			New: func() any {
 				return bytes.NewBuffer(make([]byte, 0, MaxResponseBodyLen))
@@ -24,11 +25,39 @@ func newBufferPool() *bufferPool {
 	}
 }
 
-func (p *bufferPool) Get() *bytes.Buffer {
+func (p *BufferPoolType) Get() *bytes.Buffer {
 	return p.Pool.Get().(*bytes.Buffer)
 }
 
-func (p *bufferPool) Put(v *bytes.Buffer) {
+func (p *BufferPoolType) Put(v *bytes.Buffer) {
 	v.Reset()
 	p.Pool.Put(v)
+}
+
+// PooledBody is an io.ReadCloser that wraps a restored HTTP body alongside the
+// pool buffer whose backing array is referenced by the reader. The buffer is
+// returned to pool only when Close is called, ensuring it outlives the body read.
+type PooledBody struct {
+	io.Reader
+	pool *BufferPoolType
+	buf  *bytes.Buffer
+	orig io.ReadCloser
+}
+
+// NewPooledBody constructs a PooledBody. pool is the buffer pool to return
+// captured to on Close; captured is the pool buffer that was used to tee the
+// body; orig is the original ReadCloser. The Reader presented to callers
+// replays captured followed by any remaining bytes in orig.
+func NewPooledBody(pool *BufferPoolType, captured *bytes.Buffer, orig io.ReadCloser) *PooledBody {
+	return &PooledBody{
+		Reader: io.MultiReader(bytes.NewReader(captured.Bytes()), orig),
+		pool:   pool,
+		buf:    captured,
+		orig:   orig,
+	}
+}
+
+func (b *PooledBody) Close() error {
+	b.pool.Put(b.buf)
+	return b.orig.Close()
 }

--- a/logging/http.go
+++ b/logging/http.go
@@ -5,7 +5,6 @@ package logging
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -118,8 +117,9 @@ func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, a
 		return nil
 	}
 
+	// original is borrowed from the pool and teed into while scanning. Ownership
+	// is transferred to NewPooledBody, which returns it to the pool on Close.
 	original := BufferPool.Get()
-	defer BufferPool.Put(original)
 
 	tee := io.TeeReader(req.Body, original)
 
@@ -127,13 +127,14 @@ func (l *defaultRequestBodyLogger) Log(ctx context.Context, req *http.Request, a
 
 	body, err := ReadTruncatedBody(scanner, maxRequestBodyLen)
 	if err != nil {
+		BufferPool.Put(original)
 		return err
 	}
 
 	*attrs = append(*attrs, attribute.String("http.request.body", body))
 
 	// Restore the full body for the SDK serialiser.
-	req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(original.Bytes()), req.Body))
+	req.Body = NewPooledBody(BufferPool, original, req.Body)
 
 	return nil
 }

--- a/logging/http_test.go
+++ b/logging/http_test.go
@@ -125,5 +125,6 @@ func BenchmarkRequestBodyLogger(b *testing.B) {
 		if err := logger.Log(b.Context(), req, &attrs); err != nil {
 			b.Fatal(err)
 		}
+		req.Body.Close()
 	}
 }


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Reference: #0000 <!--- Pull Requests should have an associated issue or may be closed --->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the libr
## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

## Description

The PR #1496 introduced a bug where the `bytes.Buffer` was returned to the shared pool too early, allowing other API requests or responses to overwrite the buffer.

This PR retains the buffer until the request or response has been fully read. While this retains the buffer slightly longer than strictly necessary, in practice this will still result in fewer memory allocations overall.

```
pkg: github.com/hashicorp/aws-sdk-go-base/v2
                      │ before (buggy)  │        after (fixed)          │
                      │     sec/op      │    sec/op     vs base         │
ResponseBodyLogger-10      29.50µ ± 13%   30.41µ ± 21%  ~ (p=0.485 n=6)

                      │      B/op       │     B/op      vs base        │
ResponseBodyLogger-10      26.76Ki ± 0%   26.80Ki ± 0%  +0.12% (p=0.002 n=6)

                      │    allocs/op    │ allocs/op   vs base          │
ResponseBodyLogger-10        22.00 ± 0%   22.00 ± 0%  ~ (p=1.000 n=6)

pkg: github.com/hashicorp/aws-sdk-go-base/v2/logging
                     │ before (buggy)  │       after (fixed)          │
                     │     sec/op      │   sec/op     vs base         │
RequestBodyLogger-10       9.980µ ± 3%   9.725µ ± 4%  ~ (p=0.180 n=6)

                     │      B/op       │     B/op      vs base        │
RequestBodyLogger-10      8.792Ki ± 0%   8.813Ki ± 0%  +0.25% (p=0.002 n=6)

                     │    allocs/op    │ allocs/op   vs base          │
RequestBodyLogger-10        18.00 ± 0%   18.00 ± 0%  ~ (p=1.000 n=6)```